### PR TITLE
SQLite persistence layer (Issue #2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Build artifacts
+**/bin/
+**/obj/
+
+# User secrets / local data
+*.db
+*.db-shm
+*.db-wal
+*.sqlite
+App_Data/
+!ReceptRegister.Api/App_Data/   # keep directory reference if needed (will still ignore contents)
+
+# VS / tooling
+.vs/
+*.user
+*.suo
+*.userprefs
+
+# OS noise
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+
+# Coverage
+coverage/
+*.lcov
+

--- a/README.md
+++ b/README.md
@@ -45,4 +45,14 @@ Your shelves stay beautiful, your pages stay clean, and your baking time goes in
 - Attach photos of results for inspiration.
 - Print or share a shortlist when planning a baking day.
 
+## Data storage (early alpha)
+The API persists data to a local SQLite file at `App_Data/receptregister.db` (created on first run). Schema is simple:
+- Recipes (Name, Book, Page, Notes, Tried)
+- Categories & Keywords (unique name each, stored lowercase)
+- Join tables (`RecipeCategories`, `RecipeKeywords`) for many-to-many links
+
+Foreign keys are enforced, and removing a recipe cascades its join rows. Category / keyword master rows remain (so taxonomy grows as you add terms). Back up is as easy as copying the single `.db` file while the app is stopped.
+
+In future milestones this may evolve (migrations, encryption, cloud backup), but for now the priority is a small, dependency-light foundation you can understand at a glance.
+
 — “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson

--- a/ReceptRegister.Api/Data/Repositories.cs
+++ b/ReceptRegister.Api/Data/Repositories.cs
@@ -1,0 +1,260 @@
+using Microsoft.Data.Sqlite;
+using ReceptRegister.Api.Domain;
+
+namespace ReceptRegister.Api.Data;
+
+public interface IRecipesRepository
+{
+    Task<int> AddAsync(Recipe recipe, IEnumerable<string> categories, IEnumerable<string> keywords, CancellationToken ct = default);
+    Task<Recipe?> GetByIdAsync(int id, CancellationToken ct = default);
+    Task UpdateAsync(Recipe recipe, IEnumerable<string> categories, IEnumerable<string> keywords, CancellationToken ct = default);
+    Task DeleteAsync(int id, CancellationToken ct = default);
+    Task ToggleTriedAsync(int id, bool tried, CancellationToken ct = default);
+    Task<IReadOnlyList<Recipe>> SearchAsync(string? term, CancellationToken ct = default);
+}
+
+public interface ITaxonomyRepository
+{
+    Task<IReadOnlyList<Category>> ListCategoriesAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<Keyword>> ListKeywordsAsync(CancellationToken ct = default);
+}
+
+public class RecipesRepository : IRecipesRepository
+{
+    private readonly ISqliteConnectionFactory _factory;
+    public RecipesRepository(ISqliteConnectionFactory factory) => _factory = factory;
+
+    public async Task<int> AddAsync(Recipe recipe, IEnumerable<string> categories, IEnumerable<string> keywords, CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        await using var tx = await conn.BeginTransactionAsync(ct);
+
+        var insertCmd = conn.CreateCommand();
+        insertCmd.CommandText = @"INSERT INTO Recipes (Name, Book, Page, Notes, Tried) VALUES ($n,$b,$p,$no,$t); SELECT last_insert_rowid();";
+        insertCmd.Parameters.AddWithValue("$n", recipe.Name);
+        insertCmd.Parameters.AddWithValue("$b", recipe.Book);
+        insertCmd.Parameters.AddWithValue("$p", recipe.Page);
+        insertCmd.Parameters.AddWithValue("$no", (object?)recipe.Notes ?? DBNull.Value);
+        insertCmd.Parameters.AddWithValue("$t", recipe.Tried ? 1 : 0);
+        var idObj = await insertCmd.ExecuteScalarAsync(ct);
+        if (idObj is null)
+            throw new InvalidOperationException("Failed to retrieve new recipe id");
+        var id = Convert.ToInt64(idObj);
+        recipe.Id = checked((int)id);
+
+        await UpsertTaxonomyAndLink(conn, "Categories", "RecipeCategories", "CategoryId", recipe.Id, categories, ct);
+        await UpsertTaxonomyAndLink(conn, "Keywords", "RecipeKeywords", "KeywordId", recipe.Id, keywords, ct);
+
+        await tx.CommitAsync(ct);
+        return recipe.Id;
+    }
+
+    public async Task<Recipe?> GetByIdAsync(int id, CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        var recipe = await GetCoreRecipe(conn, id, ct);
+        if (recipe == null) return null;
+        await LoadJoins(conn, recipe, ct);
+        return recipe;
+    }
+
+    public async Task UpdateAsync(Recipe recipe, IEnumerable<string> categories, IEnumerable<string> keywords, CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        await using var tx = await conn.BeginTransactionAsync(ct);
+
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = @"UPDATE Recipes SET Name=$n, Book=$b, Page=$p, Notes=$no, Tried=$t WHERE Id=$id";
+        cmd.Parameters.AddWithValue("$n", recipe.Name);
+        cmd.Parameters.AddWithValue("$b", recipe.Book);
+        cmd.Parameters.AddWithValue("$p", recipe.Page);
+        cmd.Parameters.AddWithValue("$no", (object?)recipe.Notes ?? DBNull.Value);
+        cmd.Parameters.AddWithValue("$t", recipe.Tried ? 1 : 0);
+        cmd.Parameters.AddWithValue("$id", recipe.Id);
+        await cmd.ExecuteNonQueryAsync(ct);
+
+        await ReplaceLinks(conn, recipe.Id, "RecipeCategories", categories, "Categories", "CategoryId", ct);
+        await ReplaceLinks(conn, recipe.Id, "RecipeKeywords", keywords, "Keywords", "KeywordId", ct);
+
+        await tx.CommitAsync(ct);
+    }
+
+    public async Task DeleteAsync(int id, CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "DELETE FROM Recipes WHERE Id=$id";
+        cmd.Parameters.AddWithValue("$id", id);
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    public async Task ToggleTriedAsync(int id, bool tried, CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "UPDATE Recipes SET Tried=$t WHERE Id=$id";
+        cmd.Parameters.AddWithValue("$t", tried ? 1 : 0);
+        cmd.Parameters.AddWithValue("$id", id);
+        await cmd.ExecuteNonQueryAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<Recipe>> SearchAsync(string? term, CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        var list = new List<Recipe>();
+        var cmd = conn.CreateCommand();
+        if (string.IsNullOrWhiteSpace(term))
+        {
+            cmd.CommandText = "SELECT Id, Name, Book, Page, Notes, Tried FROM Recipes ORDER BY Name LIMIT 200";
+        }
+        else
+        {
+            cmd.CommandText = @"SELECT DISTINCT r.Id, r.Name, r.Book, r.Page, r.Notes, r.Tried
+                               FROM Recipes r
+                               LEFT JOIN RecipeCategories rc ON rc.RecipeId=r.Id
+                               LEFT JOIN Categories c ON c.Id=rc.CategoryId
+                               LEFT JOIN RecipeKeywords rk ON rk.RecipeId=r.Id
+                               LEFT JOIN Keywords k ON k.Id=rk.KeywordId
+                               WHERE r.Name LIKE $q OR r.Book LIKE $q OR c.Name LIKE $q OR k.Name LIKE $q
+                               ORDER BY r.Name LIMIT 200";
+            cmd.Parameters.AddWithValue("$q", $"%{term}%");
+        }
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+        {
+            list.Add(new Recipe
+            {
+                Id = reader.GetInt32(0),
+                Name = reader.GetString(1),
+                Book = reader.GetString(2),
+                Page = reader.GetInt32(3),
+                Notes = reader.IsDBNull(4) ? null : reader.GetString(4),
+                Tried = reader.GetInt32(5) == 1
+            });
+        }
+
+        // Load joins for each (N+1 ok for small initial scope; can optimize later)
+        foreach (var r in list)
+            await LoadJoins(conn, r, ct);
+
+        return list;
+    }
+
+    private static async Task<Recipe?> GetCoreRecipe(SqliteConnection conn, int id, CancellationToken ct)
+    {
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id, Name, Book, Page, Notes, Tried FROM Recipes WHERE Id=$id";
+        cmd.Parameters.AddWithValue("$id", id);
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        if (!await reader.ReadAsync(ct)) return null;
+        return new Recipe
+        {
+            Id = reader.GetInt32(0),
+            Name = reader.GetString(1),
+            Book = reader.GetString(2),
+            Page = reader.GetInt32(3),
+            Notes = reader.IsDBNull(4) ? null : reader.GetString(4),
+            Tried = reader.GetInt32(5) == 1
+        };
+    }
+
+    private static async Task LoadJoins(SqliteConnection conn, Recipe recipe, CancellationToken ct)
+    {
+        // Categories
+        var catCmd = conn.CreateCommand();
+        catCmd.CommandText = @"SELECT c.Id, c.Name FROM Categories c
+                               INNER JOIN RecipeCategories rc ON rc.CategoryId=c.Id
+                               WHERE rc.RecipeId=$id ORDER BY c.Name";
+        catCmd.Parameters.AddWithValue("$id", recipe.Id);
+        await using (var reader = await catCmd.ExecuteReaderAsync(ct))
+        {
+            while (await reader.ReadAsync(ct))
+                recipe.Categories.Add(new Category(reader.GetInt32(0), reader.GetString(1)));
+        }
+
+        // Keywords
+        var keyCmd = conn.CreateCommand();
+        keyCmd.CommandText = @"SELECT k.Id, k.Name FROM Keywords k
+                               INNER JOIN RecipeKeywords rk ON rk.KeywordId=k.Id
+                               WHERE rk.RecipeId=$id ORDER BY k.Name";
+        keyCmd.Parameters.AddWithValue("$id", recipe.Id);
+        await using (var reader = await keyCmd.ExecuteReaderAsync(ct))
+        {
+            while (await reader.ReadAsync(ct))
+                recipe.Keywords.Add(new Keyword(reader.GetInt32(0), reader.GetString(1)));
+        }
+    }
+
+    private static async Task UpsertTaxonomyAndLink(SqliteConnection conn, string table, string linkTable, string linkFkName, int recipeId, IEnumerable<string> names, CancellationToken ct)
+    {
+        foreach (var raw in names.Select(n => n.Trim()).Where(n => n.Length > 0))
+        {
+            var name = raw.ToLowerInvariant(); // uniqueness case-insensitive
+            // Upsert pattern: try insert, ignore conflict, then select id
+            var insert = conn.CreateCommand();
+            insert.CommandText = $"INSERT INTO {table} (Name) VALUES ($n) ON CONFLICT(Name) DO NOTHING;";
+            insert.Parameters.AddWithValue("$n", name);
+            await insert.ExecuteNonQueryAsync(ct);
+            var sel = conn.CreateCommand();
+            sel.CommandText = $"SELECT Id FROM {table} WHERE Name=$n";
+            sel.Parameters.AddWithValue("$n", name);
+            var idObj = await sel.ExecuteScalarAsync(ct) ?? throw new InvalidOperationException($"Failed to resolve Id for {table} name '{name}'");
+            var id = Convert.ToInt32(idObj);
+
+            var link = conn.CreateCommand();
+            link.CommandText = $"INSERT OR IGNORE INTO {linkTable} (RecipeId, {linkFkName}) VALUES ($r,$t)";
+            link.Parameters.AddWithValue("$r", recipeId);
+            link.Parameters.AddWithValue("$t", id);
+            await link.ExecuteNonQueryAsync(ct);
+        }
+    }
+
+    private static async Task ReplaceLinks(SqliteConnection conn, int recipeId, string linkTable, IEnumerable<string> names, string lookupTable, string linkFkName, CancellationToken ct)
+    {
+        // Clear existing
+        var del = conn.CreateCommand();
+        del.CommandText = $"DELETE FROM {linkTable} WHERE RecipeId=$r";
+        del.Parameters.AddWithValue("$r", recipeId);
+        await del.ExecuteNonQueryAsync(ct);
+
+        await UpsertTaxonomyAndLink(conn, lookupTable, linkTable, linkFkName, recipeId, names, ct);
+    }
+}
+
+public class TaxonomyRepository : ITaxonomyRepository
+{
+    private readonly ISqliteConnectionFactory _factory;
+    public TaxonomyRepository(ISqliteConnectionFactory factory) => _factory = factory;
+
+    public async Task<IReadOnlyList<Category>> ListCategoriesAsync(CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id, Name FROM Categories ORDER BY Name";
+        var list = new List<Category>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            list.Add(new Category(reader.GetInt32(0), reader.GetString(1)));
+        return list;
+    }
+
+    public async Task<IReadOnlyList<Keyword>> ListKeywordsAsync(CancellationToken ct = default)
+    {
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        var cmd = conn.CreateCommand();
+        cmd.CommandText = "SELECT Id, Name FROM Keywords ORDER BY Name";
+        var list = new List<Keyword>();
+        await using var reader = await cmd.ExecuteReaderAsync(ct);
+        while (await reader.ReadAsync(ct))
+            list.Add(new Keyword(reader.GetInt32(0), reader.GetString(1)));
+        return list;
+    }
+}

--- a/ReceptRegister.Api/Data/SchemaInitializer.cs
+++ b/ReceptRegister.Api/Data/SchemaInitializer.cs
@@ -1,0 +1,63 @@
+using Microsoft.Data.Sqlite;
+
+namespace ReceptRegister.Api.Data;
+
+public static class SchemaInitializer
+{
+    public static async Task InitializeAsync(ISqliteConnectionFactory factory, CancellationToken ct = default)
+    {
+        await using var conn = factory.Create();
+        await conn.OpenAsync(ct);
+        await using var tx = await conn.BeginTransactionAsync(ct);
+
+        var commands = new[]
+        {
+            // Recipes core table
+            @"CREATE TABLE IF NOT EXISTS Recipes (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL,
+                Book TEXT NOT NULL,
+                Page INTEGER NOT NULL,
+                Notes TEXT NULL,
+                Tried INTEGER NOT NULL DEFAULT 0
+            );",
+            // Categories & Keywords
+            @"CREATE TABLE IF NOT EXISTS Categories (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL UNIQUE
+            );",
+            @"CREATE TABLE IF NOT EXISTS Keywords (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL UNIQUE
+            );",
+            // Join tables
+            @"CREATE TABLE IF NOT EXISTS RecipeCategories (
+                RecipeId INTEGER NOT NULL,
+                CategoryId INTEGER NOT NULL,
+                PRIMARY KEY (RecipeId, CategoryId),
+                FOREIGN KEY (RecipeId) REFERENCES Recipes(Id) ON DELETE CASCADE,
+                FOREIGN KEY (CategoryId) REFERENCES Categories(Id) ON DELETE CASCADE
+            );",
+            @"CREATE TABLE IF NOT EXISTS RecipeKeywords (
+                RecipeId INTEGER NOT NULL,
+                KeywordId INTEGER NOT NULL,
+                PRIMARY KEY (RecipeId, KeywordId),
+                FOREIGN KEY (RecipeId) REFERENCES Recipes(Id) ON DELETE CASCADE,
+                FOREIGN KEY (KeywordId) REFERENCES Keywords(Id) ON DELETE CASCADE
+            );",
+            // Helpful indexes
+            "CREATE INDEX IF NOT EXISTS IX_Recipes_Name ON Recipes(Name);",
+            "CREATE INDEX IF NOT EXISTS IX_Categories_Name ON Categories(Name);",
+            "CREATE INDEX IF NOT EXISTS IX_Keywords_Name ON Keywords(Name);"
+        };
+
+        foreach (var sql in commands)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        await tx.CommitAsync(ct);
+    }
+}

--- a/ReceptRegister.Api/Data/SqliteConnectionFactory.cs
+++ b/ReceptRegister.Api/Data/SqliteConnectionFactory.cs
@@ -1,0 +1,31 @@
+using Microsoft.Data.Sqlite;
+
+namespace ReceptRegister.Api.Data;
+
+public interface ISqliteConnectionFactory
+{
+    SqliteConnection Create();
+}
+
+public class SqliteConnectionFactory : ISqliteConnectionFactory
+{
+    private readonly string _connectionString;
+
+    public SqliteConnectionFactory(IConfiguration config, IWebHostEnvironment env)
+    {
+        var dataDir = Path.Combine(env.ContentRootPath, "App_Data");
+        Directory.CreateDirectory(dataDir);
+        var dbPath = Path.Combine(dataDir, "receptregister.db");
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = dbPath,
+            ForeignKeys = true
+        }.ToString();
+    }
+
+    public SqliteConnection Create()
+    {
+        var conn = new SqliteConnection(_connectionString);
+        return conn;
+    }
+}

--- a/ReceptRegister.Api/Domain/Models.cs
+++ b/ReceptRegister.Api/Domain/Models.cs
@@ -1,0 +1,16 @@
+namespace ReceptRegister.Api.Domain;
+
+public record Category(int Id, string Name);
+public record Keyword(int Id, string Name);
+
+public class Recipe
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Book { get; set; } = string.Empty;
+    public int Page { get; set; }
+    public string? Notes { get; set; }
+    public bool Tried { get; set; }
+    public List<Category> Categories { get; } = new();
+    public List<Keyword> Keywords { get; } = new();
+}

--- a/ReceptRegister.Tests/ReceptRegister.Tests.csproj
+++ b/ReceptRegister.Tests/ReceptRegister.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+    <ItemGroup>
+      <ProjectReference Include="..\ReceptRegister.Api\ReceptRegister.Api.csproj" />
+    </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/ReceptRegister.Tests/RecipeRepositoryTests.cs
+++ b/ReceptRegister.Tests/RecipeRepositoryTests.cs
@@ -1,0 +1,81 @@
+using ReceptRegister.Api.Data;
+using ReceptRegister.Api.Domain;
+using Microsoft.Data.Sqlite;
+
+namespace ReceptRegister.Tests;
+
+public class TempConnectionFactory : ISqliteConnectionFactory
+{
+    private readonly string _cs;
+    public TempConnectionFactory()
+    {
+        var file = Path.Combine(Path.GetTempPath(), $"recept-test-{Guid.NewGuid():N}.db");
+        _cs = new SqliteConnectionStringBuilder { DataSource = file, ForeignKeys = true }.ToString();
+    }
+    public SqliteConnection Create() => new(_cs);
+}
+
+public class RecipeRepositoryTests
+{
+    private async Task<(IRecipesRepository recipes, ITaxonomyRepository taxonomy)> CreateReposAsync()
+    {
+        var factory = new TempConnectionFactory();
+        await SchemaInitializer.InitializeAsync(factory);
+        return (new RecipesRepository(factory), new TaxonomyRepository(factory));
+    }
+
+    [Fact]
+    public async Task Add_Get_Update_Search_Delete_Flow()
+    {
+        var (repo, tax) = await CreateReposAsync();
+
+        var recipe = new Recipe
+        {
+            Name = "Kanelbullar",
+            Book = "Bröd och Bageri",
+            Page = 123,
+            Notes = "Classic Swedish buns",
+            Tried = false
+        };
+        var id = await repo.AddAsync(recipe, new[] { "Buns", "Swedish" }, new[] { "cardamom", "yeast" });
+        Assert.True(id > 0);
+
+        var fetched = await repo.GetByIdAsync(id);
+        Assert.NotNull(fetched);
+        Assert.Equal(2, fetched!.Categories.Count);
+        Assert.Equal(2, fetched.Keywords.Count);
+
+        // Update
+        fetched.Notes = "Add pearl sugar";
+        fetched.Tried = true;
+        await repo.UpdateAsync(fetched, new[] { "Buns" }, new[] { "cardamom", "sweet" });
+
+        var updated = await repo.GetByIdAsync(id);
+        Assert.NotNull(updated);
+        Assert.Single(updated!.Categories);
+        Assert.Equal(2, updated.Keywords.Count);
+        Assert.True(updated.Tried);
+        Assert.Contains("pearl", updated.Notes!);
+
+        // Search by keyword
+        var search = await repo.SearchAsync("sweet");
+        Assert.Single(search);
+        Assert.Equal(id, search[0].Id);
+
+        // Toggle tried off
+        await repo.ToggleTriedAsync(id, false);
+        var toggled = await repo.GetByIdAsync(id);
+        Assert.False(toggled!.Tried);
+
+        // Delete
+        await repo.DeleteAsync(id);
+        var deleted = await repo.GetByIdAsync(id);
+        Assert.Null(deleted);
+
+        // Taxonomy lists contain categories / keywords (even after recipe deleted; we keep dictionary values)
+        var categories = await tax.ListCategoriesAsync();
+        var keywords = await tax.ListKeywordsAsync();
+        Assert.Contains(categories, c => c.Name == "buns");
+        Assert.Contains(keywords, k => k.Name == "sweet");
+    }
+}


### PR DESCRIPTION
## Summary
Implements Issue #2: introduce a lightweight SQLite persistence layer for recipes with categories and keywords.

## Key additions
- Data layer (no ORM) using `Microsoft.Data.Sqlite`
- Schema initializer creating tables + indexes on startup
- Repository pattern:
  - `IRecipesRepository` (Add, Get, Update, Delete, ToggleTried, Search)
  - `ITaxonomyRepository` (list categories / keywords)
- Integration test (`RecipeRepositoryTests`) covering full CRUD + taxonomy behavior
- Added `.gitignore` to exclude build artifacts and local db files
- Updated `README.md` with data storage section

## Design notes
- Case-insensitive uniqueness for taxonomy achieved by lowercasing input prior to insert/select
- Foreign keys enabled; cascade deletes remove join rows but retain taxonomy terms
- Startup (API) should call `SchemaInitializer.InitializeAsync(...)` (already wired if Program.cs retains earlier change)

## Testing
`dotnet test` (local) passes: integration test validates full lifecycle

## Next steps / future improvements
- Expose REST endpoints for CRUD/search
- Add filtering by Tried state in repository API or query layer
- Introduce simple migration/version table when schema evolves
- Consider adding an index on `Tried` if filtering becomes common

Closes #2
