### PR TITLE
chore: branch cleanup policy docs + prune script

### DIFF
--- a/.copilot/copilot-instructions.md
+++ b/.copilot/copilot-instructions.md
@@ -97,6 +97,9 @@ Hello there! I’m Bagare Bengtsson: professional baker by dawn, software develo
 - Releases (optional for later):  
   - Tag main with v0.x.y when producing packaged builds; keep a short Release notes section summarizing changes and breaking notes.
 
+### Branch cleanup policy (for Copilot awareness)
+After a PR is squash‑merged, its feature branch must be deleted (local + remote) within 24 hours unless there is a documented follow‑up requiring it to persist. Temporary linearization / backup branches (e.g. `*-linear`, `backup/*`) are deleted immediately after use. If historical preservation is needed, create an annotated tag (`archive/<slug>`) before deletion. Copilot should proactively suggest pruning merged branches when it detects they are ancestors of `origin/main` and not referenced by an open PR.
+
 ## Handling ambiguity
 - State 1–2 reasonable assumptions explicitly and proceed.  
 - Offer alternatives with quick pros/cons.  

--- a/tools/prune-merged.ps1
+++ b/tools/prune-merged.ps1
@@ -1,0 +1,59 @@
+<#!
+.SYNOPSIS
+    Archive (tag) and delete merged or stale feature branches.
+.DESCRIPTION
+    Finds remote branches (excluding protected set) whose tips are ancestors of origin/main OR
+    whose diff to origin/main is empty (identical tree). Archives each via annotated tag
+    then deletes remote and local refs.
+.PARAMETER Protected
+    Array of protected branch names (default: main)
+.PARAMETER Keep
+    Array of branch names to skip even if merged (e.g., active PR branches)
+.EXAMPLE
+    ./tools/prune-merged.ps1 -Keep 'feat/active-99-something'
+#>
+param(
+  [string[]]$Protected = @('main'),
+  [string[]]$Keep = @()
+)
+
+Write-Host "[prune] Fetching refs..." -ForegroundColor Cyan
+& git fetch origin --prune | Out-Null
+
+$current = (& git rev-parse --abbrev-ref HEAD).Trim()
+$branches = & git for-each-ref --format='%(refname:short)' refs/remotes/origin |
+  Where-Object { $_ -notmatch 'origin/(HEAD|main)$' } |
+  ForEach-Object { $_ -replace '^origin/', '' }
+
+if (-not $branches) { Write-Host '[prune] No remote branches found.'; exit 0 }
+
+$mainSha = (& git rev-parse origin/main).Trim()
+$pruned = @()
+$skipped = @()
+
+foreach ($b in $branches) {
+  if ($Protected -contains $b) { $skipped += "$b (protected)"; continue }
+  if ($Keep -contains $b) { $skipped += "$b (keep list)"; continue }
+  if ($b -eq $current) { $skipped += "$b (current)"; continue }
+  $remoteRef = "origin/$b"
+  $exists = & git show-ref --verify --quiet refs/remotes/origin/$b; if ($LASTEXITCODE -ne 0) { $skipped += "$b (no remote)"; continue }
+  $tipSha = (& git rev-parse $remoteRef).Trim()
+  # Condition 1: branch tip is ancestor of main
+  & git merge-base --is-ancestor $tipSha $mainSha
+  $isAncestor = ($LASTEXITCODE -eq 0)
+  # Condition 2: identical tree (no diff)
+  $diff = & git diff --name-only $tipSha $mainSha
+  $identical = -not $diff
+  if (-not ($isAncestor -or $identical)) { $skipped += "$b (not merged)"; continue }
+  $tag = "archive/" + ($b -replace '/','-') + "-" + $tipSha.Substring(0,8)
+  Write-Host "[prune] Archiving $b as $tag" -ForegroundColor Yellow
+  & git tag -a $tag $tipSha -m "Archive snapshot before pruning $b" 2>$null
+  & git push origin $tag | Out-Null
+  & git push origin --delete $b | Out-Null
+  & git show-ref --verify --quiet refs/heads/$b; if ($LASTEXITCODE -eq 0) { & git branch -D $b | Out-Null }
+  $pruned += $b
+}
+
+Write-Host "[prune] Done." -ForegroundColor Cyan
+Write-Host "Pruned:  $($pruned -join ', ' )"
+Write-Host "Skipped: $($skipped -join ', ')"


### PR DESCRIPTION
Summary
Adds documented branch cleanup policy to CONTRIBUTING and Copilot instructions plus a PowerShell automation script tools/prune-merged.ps1 to archive (tag) and delete merged branches.

Details
- CONTRIBUTING.md: New section describing archive tag naming, fast-forward + squash policies, and pruning cadence.
- .copilot/copilot-instructions.md: Mirrors policy so automated assistance follows it.
- tools/prune-merged.ps1: Automatically identifies fully merged branches, creates archive tags (archive/<branch>-<shortsha>), pushes tags, and deletes remote branches.

Rationale
Codifies the linear history & hygiene expectations we followed in PR #77 and prevents drift / accumulation of stale branches.

Notes
- No issue is auto-closed; this is operational/docs only.
- Feature branch feat/frontend-5-ui-foundation was archived via tag archive/feat-frontend-5-ui-foundation-final then removed (remote + local) prior to this PR; tag preserves its final tip.

Validation
Script was reviewed locally; non-destructive dry-run capability can be added in a future enhancement if desired.

Next
After merge: delete this chore branch. Optionally squash merge to keep a single commit (not required).

No breaking changes.