### PR TITLE
a11y: table row focus outline + semantic disabled pagination (Closes #85 #90 #91)

### DIFF
--- a/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
+++ b/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
@@ -113,13 +113,13 @@
             <div>
                 @if (Model.Result.Page > 1) {
                     <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page-1)&PageSize=@Model.Result.PageSize" rel="prev">Prev</a>
-                } else { <span class="btn btn--subtle btn--sm" style="pointer-events:none;opacity:.5;">Prev</span> }
+                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">Prev</span> }
             </div>
             <div><span aria-current="page">Page @Model.Result.Page of @Model.Result.TotalPages</span></div>
             <div>
                 @if (Model.Result.Page < Model.Result.TotalPages) {
                     <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page+1)&PageSize=@Model.Result.PageSize" rel="next">Next</a>
-                } else { <span class="btn btn--subtle btn--sm" style="pointer-events:none;opacity:.5;">Next</span> }
+                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">Next</span> }
             </div>
         </div>
     </nav>

--- a/ReceptRegister.Frontend/wwwroot/css/table.css
+++ b/ReceptRegister.Frontend/wwwroot/css/table.css
@@ -4,6 +4,7 @@ th, td { text-align:left; padding:.4rem .5rem; vertical-align:top; }
 thead th { background:var(--color-surface-alt); font-weight:600; border-bottom:2px solid var(--color-border-strong); }
 tbody tr:nth-child(even) { background:var(--color-surface-alt); }
 tbody tr:hover { background:var(--color-table-hover); }
+tbody tr:focus-within { outline:2px solid var(--color-focus-outline); outline-offset:2px; }
 td a { text-decoration:none; }
 td a:focus, td a:hover { text-decoration:underline; }
 .recipes-table { margin-top:.75rem; }


### PR DESCRIPTION
Enhancements:

- Add keyboard focus visibility to data rows: `tbody tr:focus-within` outline using design token `--color-focus-outline` (improves navigability for keyboard / screen reader users). (#90)
- Replace purely visual disabled Prev/Next pagination placeholders with semantic `<span aria-disabled="true">…</span>` (improves accessibility semantics). (#91)
- Confirms design tokens foundation (#85) in use for the new styles.

Rationale:
Keyboard users lacked a clear indication of which row currently contains focusable elements (links / buttons). Adding an outline on `:focus-within` mirrors accessible data grid guidance. Pagination previously used inline styles and pointer-events; now uses `aria-disabled` for clearer semantics.

No functional logic changes—CSS + markup accessibility adjustments only.

Testing steps:
1. Navigate the recipes table with Tab: row outline should appear around the row containing the focused link/button.
2. Paginate to first/last page: Prev/Next disabled states should be visually distinct and have `aria-disabled="true"`.
3. Verify contrast still passes in dark and contrast themes.

Closes #85, #90, #91.
