### PR TITLE
feat: a11y table row focus outline & semantic disabled pagination

### DIFF
--- a/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
+++ b/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
@@ -113,13 +113,13 @@
             <div>
                 @if (Model.Result.Page > 1) {
                     <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page-1)&PageSize=@Model.Result.PageSize" rel="prev">Prev</a>
-                } else { <span class="btn btn--subtle btn--sm" style="pointer-events:none;opacity:.5;">Prev</span> }
+                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">Prev</span> }
             </div>
             <div><span aria-current="page">Page @Model.Result.Page of @Model.Result.TotalPages</span></div>
             <div>
                 @if (Model.Result.Page < Model.Result.TotalPages) {
                     <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page+1)&PageSize=@Model.Result.PageSize" rel="next">Next</a>
-                } else { <span class="btn btn--subtle btn--sm" style="pointer-events:none;opacity:.5;">Next</span> }
+                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">Next</span> }
             </div>
         </div>
     </nav>

--- a/ReceptRegister.Frontend/wwwroot/css/table.css
+++ b/ReceptRegister.Frontend/wwwroot/css/table.css
@@ -4,6 +4,7 @@ th, td { text-align:left; padding:.4rem .5rem; vertical-align:top; }
 thead th { background:var(--color-surface-alt); font-weight:600; border-bottom:2px solid var(--color-border-strong); }
 tbody tr:nth-child(even) { background:var(--color-surface-alt); }
 tbody tr:hover { background:var(--color-table-hover); }
+tbody tr:focus-within { outline:2px solid var(--color-focus-outline); outline-offset:2px; }
 td a { text-decoration:none; }
 td a:focus, td a:hover { text-decoration:underline; }
 .recipes-table { margin-top:.75rem; }


### PR DESCRIPTION
Accessibility & token polish for recipe listing.

Changes:
- Add keyboard focus visibility to data rows: tbody tr:focus-within outline using token var(--color-focus-outline). (Issue #90)
- Replace purely visual disabled Prev/Next pagination placeholders with semantic <span aria-disabled="true">…</span>. (Issue #91)
- Confirms design tokens foundation (Issue #85) in use for new styling.

Rationale:
Keyboard users previously had no clear indication of the active row while navigating interactive elements inside rows. Pagination disabled state now exposes true semantic state to assistive tech instead of relying only on pointer-events styles.

Verification steps:
1. Tab through table: outline appears around entire row containing focused link/button; outline respects theme tokens in light/dark/contrast.
2. On first/last page pagination: disabled control rendered as <span aria-disabled="true">Label</span> (no focusable anchor) and announced as disabled by screen readers.
3. Contrast theme still passes expected contrast ratios; no regressions on reduced motion preference.
4. No backend / logic changes; static CSS + markup only.

Closure lines:
Closes #85
Closes #90
Closes #91
