### PR TITLE
feat(i18n): extract initial UI strings to SharedResources

### DIFF
--- a/ReceptRegister.Frontend/Pages/Recipes/Create.cshtml
+++ b/ReceptRegister.Frontend/Pages/Recipes/Create.cshtml
@@ -1,9 +1,12 @@
 @page
+@using Microsoft.Extensions.Localization
+@using ReceptRegister.Frontend.Resources
+@inject IStringLocalizer<SharedResources> L
 @model ReceptRegister.Frontend.Pages.Recipes.CreateModel
 @{
-    ViewData["Title"] = "Add Recipe";
+    ViewData["Title"] = L["Page.CreateRecipe.Title"];
 }
-<h1>Add Recipe</h1>
+<h1>@L["Page.CreateRecipe.Title"]</h1>
 <form method="post" novalidate class="recipe-form" aria-describedby="formHelp">
 @{
     var sessSettings = HttpContext.RequestServices.GetService(typeof(ReceptRegister.Api.Auth.SessionSettings)) as ReceptRegister.Api.Auth.SessionSettings;
@@ -22,48 +25,48 @@
         <input type="hidden" name="X-CSRF-TOKEN" value="@csrfValue" />
     }
 }
-    <p id="formHelp" class="hint">Fields marked * are required. Use commas to separate multiple categories or keywords.</p>
+    <p id="formHelp" class="hint">@L["Form.RequiredLegend"]</p>
     <div class="form-grid">
     <div class="field-group">
-            <label for="Name">Name <span aria-hidden="true">*</span></label>
+            <label for="Name">@L["Form.Name"] <span aria-hidden="true">*</span></label>
             <input id="Name" name="Name" type="text" value="@Model.Input.Name" aria-required="true" aria-describedby="Name_help" />
-            <div id="Name_help" class="hint">Primary display name of the recipe.</div>
+            <div id="Name_help" class="hint">@L["Form.Name.Help"]</div>
             <span class="text-danger">@Model.ModelState[nameof(Model.Input.Name)]?.Errors.FirstOrDefault()?.ErrorMessage</span>
         </div>
     <div class="field-group">
-            <label for="Book">Book <span aria-hidden="true">*</span></label>
+            <label for="Book">@L["Form.Book"] <span aria-hidden="true">*</span></label>
             <input id="Book" name="Book" type="text" value="@Model.Input.Book" aria-required="true" aria-describedby="Book_help" />
-            <div id="Book_help" class="hint">Exact book title to locate it later.</div>
+            <div id="Book_help" class="hint">@L["Form.Book.Help"]</div>
             <span class="text-danger">@Model.ModelState[nameof(Model.Input.Book)]?.Errors.FirstOrDefault()?.ErrorMessage</span>
         </div>
     <div class="field-group inline-small">
-            <label for="Page">Page <span aria-hidden="true">*</span></label>
+            <label for="Page">@L["Form.Page"] <span aria-hidden="true">*</span></label>
             <input id="Page" name="Page" type="number" value="@Model.Input.Page" aria-required="true" aria-describedby="Page_help" />
-            <div id="Page_help" class="hint">Page number in the book.</div>
+            <div id="Page_help" class="hint">@L["Form.Page.Help"]</div>
             <span class="text-danger">@Model.ModelState[nameof(Model.Input.Page)]?.Errors.FirstOrDefault()?.ErrorMessage</span>
         </div>
         <div class="field-group">
-            <label for="Categories">Categories</label>
+            <label for="Categories">@L["Form.Categories"]</label>
             <input id="Categories" name="Categories" type="text" value="@Model.Input.Categories" aria-describedby="Categories_help" />
-            <div id="Categories_help" class="hint">Comma separated (e.g. Buns, Swedish).</div>
+            <div id="Categories_help" class="hint">@L["Form.Categories.Help"]</div>
         </div>
         <div class="field-group">
-            <label for="Keywords">Keywords</label>
+            <label for="Keywords">@L["Form.Keywords"]</label>
             <input id="Keywords" name="Keywords" type="text" value="@Model.Input.Keywords" aria-describedby="Keywords_help" />
-            <div id="Keywords_help" class="hint">Ingredients / attributes (e.g. cardamom, gluten-free).</div>
+            <div id="Keywords_help" class="hint">@L["Form.Keywords.Help"]</div>
         </div>
         <div class="field-group span-2">
-            <label for="Notes">Notes</label>
+            <label for="Notes">@L["Form.Notes"]</label>
             <textarea id="Notes" name="Notes" rows="4" aria-describedby="Notes_help">@Model.Input.Notes</textarea>
-            <div id="Notes_help" class="hint">Optional personal notes.</div>
+            <div id="Notes_help" class="hint">@L["Form.Notes.Help"]</div>
         </div>
         <div class="field-group checkbox-inline span-2">
             <input type="checkbox" id="Tried" name="Tried" value="true" @(Model.Input.Tried?"checked":null) />
-            <label for="Tried">Tried</label>
+            <label for="Tried">@L["Form.Tried"]</label>
         </div>
     </div>
     <div class="actions">
-        <button type="submit" class="btn">Create</button>
-        <a href="/Recipes/Index" class="btn btn--subtle btn--sm">Cancel</a>
+    <button type="submit" class="btn">@L["Button.Create"]</button>
+    <a href="/Recipes/Index" class="btn btn--subtle btn--sm">@L["Button.Cancel"]</a>
     </div>
 </form>

--- a/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
+++ b/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
@@ -1,52 +1,55 @@
 @page
+@using Microsoft.Extensions.Localization
+@using ReceptRegister.Frontend.Resources
+@inject IStringLocalizer<SharedResources> L
 @model ReceptRegister.Frontend.Pages.Recipes.IndexModel
 @{
-    ViewData["Title"] = "Recipes";
+    ViewData["Title"] = L["Page.Recipes.Title"];
 }
-<h1><span class="icon" aria-hidden="true">🍽️</span> Recipes</h1>
+<h1><span class="icon" aria-hidden="true">🍽️</span> @L["Page.Recipes.Title"]</h1>
 <div class="card-grid-toggle">
-    <button type="button" class="btn btn--subtle btn--sm" id="toggle-layout" aria-pressed="false">Cards</button>
+    <button type="button" class="btn btn--subtle btn--sm" id="toggle-layout" aria-pressed="false">@L["Button.Cards"]</button>
 </div>
-<p id="search-results-count" class="visually-hidden" aria-live="polite" aria-atomic="true">Listing @Model.Result.TotalItems recipe@(Model.Result.TotalItems == 1 ? "" : "s") (page @Model.Result.Page of @Model.Result.TotalPages).</p>
+<p id="search-results-count" class="visually-hidden" aria-live="polite" aria-atomic="true">@string.Format(L["A11y.Recipes.ResultsCount"], Model.Result.TotalItems, (Model.Result.TotalItems == 1 ? "" : "s"), Model.Result.Page, Model.Result.TotalPages)</p>
 <form method="get" class="form-inline" role="search" aria-label="Recipe search">
-    <label for="search" class="visually-hidden">Search</label>
+    <label for="search" class="visually-hidden">@L["Button.Search"]</label>
     <input id="search" type="text" name="Search" value="@Model.Search" placeholder="Search name, book, category, keyword" />
-    <button type="submit" class="btn btn--outline btn--sm">Search</button>
+    <button type="submit" class="btn btn--outline btn--sm">@L["Button.Search"]</button>
     @if (!string.IsNullOrWhiteSpace(Model.Search)) {
-        <a href="/Recipes/Index" class="reset-link">Clear</a>
+    <a href="/Recipes/Index" class="reset-link">@L["Button.Clear"]</a>
     }
 </form>
-<p class="result-count">@Model.Result.TotalItems recipe@(Model.Result.TotalItems == 1 ? "" : "s") found. Showing page @Model.Result.Page of @Model.Result.TotalPages.</p>
+<p class="result-count">@string.Format(L["A11y.Recipes.VisibleCount"], Model.Result.TotalItems, (Model.Result.TotalItems == 1 ? "" : "s"), Model.Result.Page, Model.Result.TotalPages)</p>
 <div class="table-scroll" id="recipes-table-wrapper">
 <table class="recipes-table stackable" id="recipes-table" data-view="table">
     <caption class="visually-hidden">Recipes list with columns for name, book, page, categories, keywords, and tried status.</caption>
     <thead>
     <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Book</th>
-        <th scope="col">Page</th>
-        <th scope="col">Categories</th>
-        <th scope="col">Keywords</th>
-        <th scope="col">Tried</th>
+    <th scope="col">@L["Table.Name"]</th>
+    <th scope="col">@L["Table.Book"]</th>
+    <th scope="col">@L["Table.Page"]</th>
+    <th scope="col">@L["Table.Categories"]</th>
+    <th scope="col">@L["Table.Keywords"]</th>
+    <th scope="col">@L["Table.Tried"]</th>
     </tr>
     </thead>
     <tbody>
     @foreach (var r in Model.Result.Items) {
         <tr>
-            <td data-label="Name"><a href="/Recipes/Detail/@r.Id">@r.Name</a></td>
-            <td data-label="Book">@r.Book</td>
-            <td data-label="Page">@r.Page</td>
-            <td data-label="Categories">
+            <td data-label="@L["Table.Name"]"><a href="/Recipes/Detail/@r.Id">@r.Name</a></td>
+            <td data-label="@L["Table.Book"]">@r.Book</td>
+            <td data-label="@L["Table.Page"]">@r.Page</td>
+            <td data-label="@L["Table.Categories"]">
                 @if (r.Categories.Count == 0) { <span class="muted">—</span>; } else {
                     <ul class="inline-list" role="list">@{ var ci=0; }@foreach (var c in r.Categories) { var cls=$"cat-{(ci%5)+1}"; <li role="listitem" class="@cls">@c.Name</li>; ci++; }</ul>
                 }
             </td>
-            <td data-label="Keywords">
+            <td data-label="@L["Table.Keywords"]">
                 @if (r.Keywords.Count == 0) { <span class="muted">—</span>; } else {
                     <ul class="inline-list" role="list">@{ var ki=0; }@foreach (var k in r.Keywords) { var cls=$"key-{(ki%5)+1}"; <li role="listitem" class="@cls">@k.Name</li>; ki++; }</ul>
                 }
             </td>
-            <td data-label="Tried"><button type="button" class="link-button" data-toggle-tried data-id="@r.Id" data-tried="@r.Tried" aria-pressed="@r.Tried.ToString().ToLower()" aria-label="Toggle tried">@(r.Tried?"✔":"")</button></td>
+            <td data-label="@L["Table.Tried"]"><button type="button" class="link-button" data-toggle-tried data-id="@r.Id" data-tried="@r.Tried" aria-pressed="@r.Tried.ToString().ToLower()" aria-label="@L["A11y.ToggleTried"]">@(r.Tried?"✔":"")</button></td>
         </tr>
     }
     </tbody>
@@ -57,20 +60,20 @@
 @foreach (var r in Model.Result.Items) {
     <article class="recipe-card" data-tried="@r.Tried" data-id="@r.Id">
         <h3><a href="/Recipes/Detail/@r.Id">@r.Name</a></h3>
-        <div class="meta">@r.Book @if(r.Page>0){<span>· p.@r.Page</span>} @if(r.Tried){<span class="tried-indicator" aria-label="Tried">✔</span>}</div>
+    <div class="meta">@r.Book @if(r.Page>0){<span>· p.@r.Page</span>} @if(r.Tried){<span class="tried-indicator" aria-label="@L["Table.Tried"]">✔</span>}</div>
         <div class="taxonomy">
             @if (r.Categories.Count == 0) { <span class="muted">—</span>; } else { var ci=0; foreach (var c in r.Categories) { var cls=$"cat-{(ci%5)+1}"; <span class="chip @cls">@c.Name</span>; ci++; } }
             @if (r.Keywords.Count != 0) { var ki=0; foreach (var k in r.Keywords) { var cls=$"key-{(ki%5)+1}"; <span class="chip @cls">@k.Name</span>; ki++; } }
         </div>
         <div class="actions">
-            <a href="/Recipes/Edit/@r.Id" class="btn btn--outline btn--sm" aria-label="Edit recipe"><span aria-hidden="true">✏️</span> Edit</a>
+            <a href="/Recipes/Edit/@r.Id" class="btn btn--outline btn--sm" aria-label="@L["Button.Edit"] recipe"><span aria-hidden="true">✏️</span> @L["Button.Edit"]</a>
         </div>
     </article>
 }
 </div>
 @if (Model.Result.TotalItems == 0)
 {
-    <p class="empty">No recipes yet. <a href="/Recipes/Create">Add one</a>.</p>
+    <p class="empty">@Html.Raw(L["Page.Recipes.Empty"])</p>
 }
 
 @section Scripts {
@@ -112,14 +115,14 @@
         <div class="pager-buttons" style="display:flex;align-items:center;gap:var(--spacing-4);flex-wrap:wrap;">
             <div>
                 @if (Model.Result.Page > 1) {
-                    <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page-1)&PageSize=@Model.Result.PageSize" rel="prev">Prev</a>
-                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">Prev</span> }
+                    <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page-1)&PageSize=@Model.Result.PageSize" rel="prev">@L["Button.Prev"]</a>
+                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">@L["Button.Prev"]</span> }
             </div>
             <div><span aria-current="page">Page @Model.Result.Page of @Model.Result.TotalPages</span></div>
             <div>
                 @if (Model.Result.Page < Model.Result.TotalPages) {
-                    <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page+1)&PageSize=@Model.Result.PageSize" rel="next">Next</a>
-                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">Next</span> }
+                    <a class="btn btn--outline btn--sm" href="?Search=@Model.Search&PageNumber=@(Model.Result.Page+1)&PageSize=@Model.Result.PageSize" rel="next">@L["Button.Next"]</a>
+                } else { <span class="btn btn--subtle btn--sm" aria-disabled="true">@L["Button.Next"]</span> }
             </div>
         </div>
     </nav>

--- a/ReceptRegister.Frontend/Pages/Shared/_Layout.cshtml
+++ b/ReceptRegister.Frontend/Pages/Shared/_Layout.cshtml
@@ -1,4 +1,7 @@
-﻿<!DOCTYPE html>
+﻿@using Microsoft.Extensions.Localization
+@using ReceptRegister.Frontend.Resources
+@inject IStringLocalizer<SharedResources> L
+<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="utf-8" />
@@ -30,11 +33,11 @@
     <a href="#main" class="skip-link">Skip to content</a>
     <header>
         <p class="app-title"><a asp-page="/Index">ReceptRegister</a></p>
-        <nav class="grow" aria-label="Main navigation">
+    <nav class="grow" aria-label="Main navigation">
             <ul>
-                <li><a asp-page="/Recipes/Index" aria-current="@(Context.Request.Path.Value?.StartsWith("/Recipes", StringComparison.OrdinalIgnoreCase) == true ? "page" : null)">Recipes</a></li>
-                <li><a asp-page="/Taxonomy/Categories" aria-current="@(Context.Request.Path.Value?.Contains("/Taxonomy/Categories", StringComparison.OrdinalIgnoreCase) == true ? "page" : null)">Categories</a></li>
-                <li><a asp-page="/Taxonomy/Keywords" aria-current="@(Context.Request.Path.Value?.Contains("/Taxonomy/Keywords", StringComparison.OrdinalIgnoreCase) == true ? "page" : null)">Keywords</a></li>
+        <li><a asp-page="/Recipes/Index" aria-current="@(Context.Request.Path.Value?.StartsWith("/Recipes", StringComparison.OrdinalIgnoreCase) == true ? "page" : null)">@L["Nav.Recipes"]</a></li>
+        <li><a asp-page="/Taxonomy/Categories" aria-current="@(Context.Request.Path.Value?.Contains("/Taxonomy/Categories", StringComparison.OrdinalIgnoreCase) == true ? "page" : null)">@L["Nav.Categories"]</a></li>
+        <li><a asp-page="/Taxonomy/Keywords" aria-current="@(Context.Request.Path.Value?.Contains("/Taxonomy/Keywords", StringComparison.OrdinalIgnoreCase) == true ? "page" : null)">@L["Nav.Keywords"]</a></li>
 @{
     // Initial server-side detection; client JS (auth-ui.js) will refine
     var authed = false;
@@ -43,10 +46,10 @@
     var navCookie = navSettings?.CookieName ?? "rr_session";
     if (Context.Request.Cookies.TryGetValue(navCookie, out var navTok) && navSvc?.Validate(navTok) == true) { authed = true; }
 }
-                <li data-auth-visible="anon" style="display:@(authed?"none":"block")"><a asp-page="/Auth/Login">Login</a></li>
+                <li data-auth-visible="anon" style="display:@(authed?"none":"block")"><a asp-page="/Auth/Login">@L["Nav.Login"]</a></li>
                 <li data-auth-visible="authed" style="display:@(!authed?"none":"block")">
                     <form method="post" action="/Auth/Logout" class="inline" id="logout-form">
-                        <button type="submit" class="link-button" data-logout>Logout</button>
+                        <button type="submit" class="link-button" data-logout>@L["Nav.Logout"]</button>
                     </form>
                 </li>
             </ul>
@@ -58,7 +61,7 @@
     <footer>
         <p>&copy; @DateTime.UtcNow.Year ReceptRegister · <a asp-page="/Privacy">Privacy</a></p>
     </footer>
-    <button type="button" id="theme-toggle" class="link-button" style="position:fixed;bottom:var(--spacing-6,16px);right:var(--spacing-6,16px);">Toggle theme</button>
+    <button type="button" id="theme-toggle" class="link-button" style="position:fixed;bottom:var(--spacing-6,16px);right:var(--spacing-6,16px);">@L["Button.ToggleTheme"]</button>
     <script type="module" src="/js/modules/search-enhance.js" defer></script>
     <script type="module" src="/js/modules/toggle-tried.js" defer></script>
     <script type="module" src="/js/modules/chips.js" defer></script>

--- a/ReceptRegister.Frontend/Resources/SharedResources.cs
+++ b/ReceptRegister.Frontend/Resources/SharedResources.cs
@@ -1,0 +1,4 @@
+namespace ReceptRegister.Frontend.Resources;
+
+// Marker class used for IStringLocalizer<SharedResources> resource binding.
+public sealed class SharedResources { }

--- a/ReceptRegister.Frontend/Resources/SharedResources.resx
+++ b/ReceptRegister.Frontend/Resources/SharedResources.resx
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <!-- Navigation -->
+  <data name="Nav.Recipes" xml:space="preserve"><value>Recipes</value></data>
+  <data name="Nav.Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="Nav.Keywords" xml:space="preserve"><value>Keywords</value></data>
+  <data name="Nav.Login" xml:space="preserve"><value>Login</value></data>
+  <data name="Nav.Logout" xml:space="preserve"><value>Logout</value></data>
+  <!-- Buttons / Actions -->
+  <data name="Button.ToggleTheme" xml:space="preserve"><value>Toggle theme</value></data>
+  <data name="Button.Search" xml:space="preserve"><value>Search</value></data>
+  <data name="Button.Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="Button.Edit" xml:space="preserve"><value>Edit</value></data>
+  <data name="Button.Create" xml:space="preserve"><value>Create</value></data>
+  <data name="Button.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Button.Prev" xml:space="preserve"><value>Prev</value></data>
+  <data name="Button.Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Button.List" xml:space="preserve"><value>List</value></data>
+  <data name="Button.Cards" xml:space="preserve"><value>Cards</value></data>
+  <!-- Table Headers -->
+  <data name="Table.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Table.Book" xml:space="preserve"><value>Book</value></data>
+  <data name="Table.Page" xml:space="preserve"><value>Page</value></data>
+  <data name="Table.Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="Table.Keywords" xml:space="preserve"><value>Keywords</value></data>
+  <data name="Table.Tried" xml:space="preserve"><value>Tried</value></data>
+  <!-- Pages / Headings -->
+  <data name="Page.Recipes.Title" xml:space="preserve"><value>Recipes</value></data>
+  <data name="Page.Recipes.Empty" xml:space="preserve"><value>No recipes yet. &lt;a href=\"/Recipes/Create\">Add one&lt;/a>.</value></data>
+  <data name="Page.CreateRecipe.Title" xml:space="preserve"><value>Add Recipe</value></data>
+  <!-- Form Labels / Hints -->
+  <data name="Form.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Form.Name.Help" xml:space="preserve"><value>Primary display name of the recipe.</value></data>
+  <data name="Form.Book" xml:space="preserve"><value>Book</value></data>
+  <data name="Form.Book.Help" xml:space="preserve"><value>Exact book title to locate it later.</value></data>
+  <data name="Form.Page" xml:space="preserve"><value>Page</value></data>
+  <data name="Form.Page.Help" xml:space="preserve"><value>Page number in the book.</value></data>
+  <data name="Form.Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="Form.Categories.Help" xml:space="preserve"><value>Comma separated (e.g. Buns, Swedish).</value></data>
+  <data name="Form.Keywords" xml:space="preserve"><value>Keywords</value></data>
+  <data name="Form.Keywords.Help" xml:space="preserve"><value>Ingredients / attributes (e.g. cardamom, gluten-free).</value></data>
+  <data name="Form.Notes" xml:space="preserve"><value>Notes</value></data>
+  <data name="Form.Notes.Help" xml:space="preserve"><value>Optional personal notes.</value></data>
+  <data name="Form.Tried" xml:space="preserve"><value>Tried</value></data>
+  <data name="Form.RequiredLegend" xml:space="preserve"><value>Fields marked * are required. Use commas to separate multiple categories or keywords.</value></data>
+  <!-- Accessibility / Live Region -->
+  <data name="A11y.Recipes.ResultsCount" xml:space="preserve"><value>Listing {0} recipe{1} (page {2} of {3}).</value></data>
+  <data name="A11y.Recipes.VisibleCount" xml:space="preserve"><value>{0} recipe{1} found. Showing page {2} of {3}.</value></data>
+  <data name="A11y.ToggleTried" xml:space="preserve"><value>Toggle tried</value></data>
+</root>

--- a/ReceptRegister.Frontend/Resources/SharedResources.sv.resx
+++ b/ReceptRegister.Frontend/Resources/SharedResources.sv.resx
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype"><value>text/microsoft-resx</value></resheader>
+  <resheader name="version"><value>2.0</value></resheader>
+  <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
+  <!-- Placeholder Swedish values (currently English) to be translated in issue #100 -->
+  <data name="Nav.Recipes" xml:space="preserve"><value>Recipes</value></data>
+  <data name="Nav.Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="Nav.Keywords" xml:space="preserve"><value>Keywords</value></data>
+  <data name="Nav.Login" xml:space="preserve"><value>Login</value></data>
+  <data name="Nav.Logout" xml:space="preserve"><value>Logout</value></data>
+  <data name="Button.ToggleTheme" xml:space="preserve"><value>Toggle theme</value></data>
+  <data name="Button.Search" xml:space="preserve"><value>Search</value></data>
+  <data name="Button.Clear" xml:space="preserve"><value>Clear</value></data>
+  <data name="Button.Edit" xml:space="preserve"><value>Edit</value></data>
+  <data name="Button.Create" xml:space="preserve"><value>Create</value></data>
+  <data name="Button.Cancel" xml:space="preserve"><value>Cancel</value></data>
+  <data name="Button.Prev" xml:space="preserve"><value>Prev</value></data>
+  <data name="Button.Next" xml:space="preserve"><value>Next</value></data>
+  <data name="Button.List" xml:space="preserve"><value>List</value></data>
+  <data name="Button.Cards" xml:space="preserve"><value>Cards</value></data>
+  <data name="Table.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Table.Book" xml:space="preserve"><value>Book</value></data>
+  <data name="Table.Page" xml:space="preserve"><value>Page</value></data>
+  <data name="Table.Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="Table.Keywords" xml:space="preserve"><value>Keywords</value></data>
+  <data name="Table.Tried" xml:space="preserve"><value>Tried</value></data>
+  <data name="Page.Recipes.Title" xml:space="preserve"><value>Recipes</value></data>
+  <data name="Page.Recipes.Empty" xml:space="preserve"><value>No recipes yet. &lt;a href=\"/Recipes/Create\">Add one&lt;/a>.</value></data>
+  <data name="Page.CreateRecipe.Title" xml:space="preserve"><value>Add Recipe</value></data>
+  <data name="Form.Name" xml:space="preserve"><value>Name</value></data>
+  <data name="Form.Name.Help" xml:space="preserve"><value>Primary display name of the recipe.</value></data>
+  <data name="Form.Book" xml:space="preserve"><value>Book</value></data>
+  <data name="Form.Book.Help" xml:space="preserve"><value>Exact book title to locate it later.</value></data>
+  <data name="Form.Page" xml:space="preserve"><value>Page</value></data>
+  <data name="Form.Page.Help" xml:space="preserve"><value>Page number in the book.</value></data>
+  <data name="Form.Categories" xml:space="preserve"><value>Categories</value></data>
+  <data name="Form.Categories.Help" xml:space="preserve"><value>Comma separated (e.g. Buns, Swedish).</value></data>
+  <data name="Form.Keywords" xml:space="preserve"><value>Keywords</value></data>
+  <data name="Form.Keywords.Help" xml:space="preserve"><value>Ingredients / attributes (e.g. cardamom, gluten-free).</value></data>
+  <data name="Form.Notes" xml:space="preserve"><value>Notes</value></data>
+  <data name="Form.Notes.Help" xml:space="preserve"><value>Optional personal notes.</value></data>
+  <data name="Form.Tried" xml:space="preserve"><value>Tried</value></data>
+  <data name="Form.RequiredLegend" xml:space="preserve"><value>Fields marked * are required. Use commas to separate multiple categories or keywords.</value></data>
+  <data name="A11y.Recipes.ResultsCount" xml:space="preserve"><value>Listing {0} recipe{1} (page {2} of {3}).</value></data>
+  <data name="A11y.Recipes.VisibleCount" xml:space="preserve"><value>{0} recipe{1} found. Showing page {2} of {3}.</value></data>
+  <data name="A11y.ToggleTried" xml:space="preserve"><value>Toggle tried</value></data>
+</root>


### PR DESCRIPTION
Initial resource extraction for localization groundwork.

Summary:
- Added SharedResources.resx with grouped keys (Nav., Button., Table., Page., Form., A11y.).
- Added placeholder SharedResources.sv.resx (values still English; to be translated in #100 [no-close]).
- Introduced marker class SharedResources for IStringLocalizer binding.
- Updated _Layout, Recipes Index, Recipes Create pages to use localized strings.
- Added formatted live region strings for recipe counts (ResultsCount, VisibleCount).

Notes:
- No user culture switcher yet; fixed culture configuration per earlier implementation (#97 [no-close]).
- Keys chosen to anticipate future expansion; Swedish translation tracked separately (#100 [no-close]).

Testing:
1. Run app; UI text should match previous English strings.
2. Verify no hard-coded strings remain in modified pages (except dynamic recipe data).
3. Confirm live region content updates still function.

Closes #99
Non-closing references: #97 [no-close], #98 [no-close], #100 [no-close]