### PR TITLE
feat(i18n): add Swedish translations

### DIFF
--- a/ReceptRegister.Frontend/Resources/SharedResources.sv.resx
+++ b/ReceptRegister.Frontend/Resources/SharedResources.sv.resx
@@ -4,46 +4,46 @@
   <resheader name="version"><value>2.0</value></resheader>
   <resheader name="reader"><value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
   <resheader name="writer"><value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value></resheader>
-  <!-- Placeholder Swedish values (currently English) to be translated in issue #100 -->
-  <data name="Nav.Recipes" xml:space="preserve"><value>Recipes</value></data>
-  <data name="Nav.Categories" xml:space="preserve"><value>Categories</value></data>
-  <data name="Nav.Keywords" xml:space="preserve"><value>Keywords</value></data>
-  <data name="Nav.Login" xml:space="preserve"><value>Login</value></data>
-  <data name="Nav.Logout" xml:space="preserve"><value>Logout</value></data>
-  <data name="Button.ToggleTheme" xml:space="preserve"><value>Toggle theme</value></data>
-  <data name="Button.Search" xml:space="preserve"><value>Search</value></data>
-  <data name="Button.Clear" xml:space="preserve"><value>Clear</value></data>
-  <data name="Button.Edit" xml:space="preserve"><value>Edit</value></data>
-  <data name="Button.Create" xml:space="preserve"><value>Create</value></data>
-  <data name="Button.Cancel" xml:space="preserve"><value>Cancel</value></data>
-  <data name="Button.Prev" xml:space="preserve"><value>Prev</value></data>
-  <data name="Button.Next" xml:space="preserve"><value>Next</value></data>
-  <data name="Button.List" xml:space="preserve"><value>List</value></data>
-  <data name="Button.Cards" xml:space="preserve"><value>Cards</value></data>
-  <data name="Table.Name" xml:space="preserve"><value>Name</value></data>
-  <data name="Table.Book" xml:space="preserve"><value>Book</value></data>
-  <data name="Table.Page" xml:space="preserve"><value>Page</value></data>
-  <data name="Table.Categories" xml:space="preserve"><value>Categories</value></data>
-  <data name="Table.Keywords" xml:space="preserve"><value>Keywords</value></data>
-  <data name="Table.Tried" xml:space="preserve"><value>Tried</value></data>
-  <data name="Page.Recipes.Title" xml:space="preserve"><value>Recipes</value></data>
-  <data name="Page.Recipes.Empty" xml:space="preserve"><value>No recipes yet. &lt;a href=\"/Recipes/Create\">Add one&lt;/a>.</value></data>
-  <data name="Page.CreateRecipe.Title" xml:space="preserve"><value>Add Recipe</value></data>
-  <data name="Form.Name" xml:space="preserve"><value>Name</value></data>
-  <data name="Form.Name.Help" xml:space="preserve"><value>Primary display name of the recipe.</value></data>
-  <data name="Form.Book" xml:space="preserve"><value>Book</value></data>
-  <data name="Form.Book.Help" xml:space="preserve"><value>Exact book title to locate it later.</value></data>
-  <data name="Form.Page" xml:space="preserve"><value>Page</value></data>
-  <data name="Form.Page.Help" xml:space="preserve"><value>Page number in the book.</value></data>
-  <data name="Form.Categories" xml:space="preserve"><value>Categories</value></data>
-  <data name="Form.Categories.Help" xml:space="preserve"><value>Comma separated (e.g. Buns, Swedish).</value></data>
-  <data name="Form.Keywords" xml:space="preserve"><value>Keywords</value></data>
-  <data name="Form.Keywords.Help" xml:space="preserve"><value>Ingredients / attributes (e.g. cardamom, gluten-free).</value></data>
-  <data name="Form.Notes" xml:space="preserve"><value>Notes</value></data>
-  <data name="Form.Notes.Help" xml:space="preserve"><value>Optional personal notes.</value></data>
-  <data name="Form.Tried" xml:space="preserve"><value>Tried</value></data>
-  <data name="Form.RequiredLegend" xml:space="preserve"><value>Fields marked * are required. Use commas to separate multiple categories or keywords.</value></data>
-  <data name="A11y.Recipes.ResultsCount" xml:space="preserve"><value>Listing {0} recipe{1} (page {2} of {3}).</value></data>
-  <data name="A11y.Recipes.VisibleCount" xml:space="preserve"><value>{0} recipe{1} found. Showing page {2} of {3}.</value></data>
-  <data name="A11y.ToggleTried" xml:space="preserve"><value>Toggle tried</value></data>
+  <!-- Svenska översättningar för #100 -->
+  <data name="Nav.Recipes" xml:space="preserve"><value>Recept</value></data>
+  <data name="Nav.Categories" xml:space="preserve"><value>Kategorier</value></data>
+  <data name="Nav.Keywords" xml:space="preserve"><value>Nyckelord</value></data>
+  <data name="Nav.Login" xml:space="preserve"><value>Logga in</value></data>
+  <data name="Nav.Logout" xml:space="preserve"><value>Logga ut</value></data>
+  <data name="Button.ToggleTheme" xml:space="preserve"><value>Växla tema</value></data>
+  <data name="Button.Search" xml:space="preserve"><value>Sök</value></data>
+  <data name="Button.Clear" xml:space="preserve"><value>Nollställ</value></data>
+  <data name="Button.Edit" xml:space="preserve"><value>Redigera</value></data>
+  <data name="Button.Create" xml:space="preserve"><value>Skapa</value></data>
+  <data name="Button.Cancel" xml:space="preserve"><value>Avbryt</value></data>
+  <data name="Button.Prev" xml:space="preserve"><value>Föregående</value></data>
+  <data name="Button.Next" xml:space="preserve"><value>Nästa</value></data>
+  <data name="Button.List" xml:space="preserve"><value>Lista</value></data>
+  <data name="Button.Cards" xml:space="preserve"><value>Kort</value></data>
+  <data name="Table.Name" xml:space="preserve"><value>Namn</value></data>
+  <data name="Table.Book" xml:space="preserve"><value>Bok</value></data>
+  <data name="Table.Page" xml:space="preserve"><value>Sida</value></data>
+  <data name="Table.Categories" xml:space="preserve"><value>Kategorier</value></data>
+  <data name="Table.Keywords" xml:space="preserve"><value>Nyckelord</value></data>
+  <data name="Table.Tried" xml:space="preserve"><value>Testat</value></data>
+  <data name="Page.Recipes.Title" xml:space="preserve"><value>Recept</value></data>
+  <data name="Page.Recipes.Empty" xml:space="preserve"><value>Inga recept ännu. &lt;a href=&quot;/Recipes/Create&quot;>Lägg till ett&lt;/a>.</value></data>
+  <data name="Page.CreateRecipe.Title" xml:space="preserve"><value>Lägg till recept</value></data>
+  <data name="Form.Name" xml:space="preserve"><value>Namn</value></data>
+  <data name="Form.Name.Help" xml:space="preserve"><value>Primärt visningsnamn för receptet.</value></data>
+  <data name="Form.Book" xml:space="preserve"><value>Bok</value></data>
+  <data name="Form.Book.Help" xml:space="preserve"><value>Exakt boktitel för att hitta den senare.</value></data>
+  <data name="Form.Page" xml:space="preserve"><value>Sida</value></data>
+  <data name="Form.Page.Help" xml:space="preserve"><value>Sidnummer i boken.</value></data>
+  <data name="Form.Categories" xml:space="preserve"><value>Kategorier</value></data>
+  <data name="Form.Categories.Help" xml:space="preserve"><value>Avgränsa med kommatecken (t.ex. Bullar, Svenskt).</value></data>
+  <data name="Form.Keywords" xml:space="preserve"><value>Nyckelord</value></data>
+  <data name="Form.Keywords.Help" xml:space="preserve"><value>Ingredienser / egenskaper (t.ex. kardemumma, glutenfritt).</value></data>
+  <data name="Form.Notes" xml:space="preserve"><value>Anteckningar</value></data>
+  <data name="Form.Notes.Help" xml:space="preserve"><value>Valfria personliga anteckningar.</value></data>
+  <data name="Form.Tried" xml:space="preserve"><value>Testat</value></data>
+  <data name="Form.RequiredLegend" xml:space="preserve"><value>Fält markerade * är obligatoriska. Använd komman för att separera flera kategorier eller nyckelord.</value></data>
+  <data name="A11y.Recipes.ResultsCount" xml:space="preserve"><value>Visar {0} recept{1} (sida {2} av {3}).</value></data>
+  <data name="A11y.Recipes.VisibleCount" xml:space="preserve"><value>{0} recept{1} hittades. Visar sida {2} av {3}.</value></data>
+  <data name="A11y.ToggleTried" xml:space="preserve"><value>Växla testat</value></data>
 </root>


### PR DESCRIPTION
Adds Swedish (sv) translations for existing SharedResources keys.

Changes:
- Replaced English placeholder values in SharedResources.sv.resx with Swedish equivalents.
- Covers navigation, buttons, table headers, page headings, empty state, form labels/help, accessibility live region strings.

Notes:
- Keeps key structure identical to neutral resource file for consistency.
- Live region strings adapted for Swedish grammar ("recept"). Plural placeholder {1} still used by code logic.

Closes #100
Related (no-close): #97 [no-close]
