### PR TITLE
feat(#106): Dual schema initializer abstraction (SQLite + experimental SQL Server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,13 +174,19 @@ Notes:
 - Current schema & repositories still use SQLite-specific SQL (e.g. `last_insert_rowid()`, `INSERT OR IGNORE`). SQL Server support is being added incrementally in issues #105–#107.
 - A sample file `ReceptRegister.Api/appsettings.Database.sample.json` is included (copy/merge into your real settings file without comments if you need a template).
 
-Planned follow-ups (tracked in the Epic #110):
-1. Provider-specific schema initialization (#106)
-2. Neutral SQL for repositories / dialect adjustments (#107)
-3. Data migration helper (#108)
-4. Documentation expansion (#109)
+Progress (Epic #110):
+1. Provider-specific schema initialization (#106) – DONE: a provider abstraction (`ISchemaInitializer`) now creates either the SQLite or SQL Server schema at startup.
+2. Neutral SQL for repositories / dialect adjustments (#107) – IN PROGRESS NEXT: repository queries still contain SQLite-only constructs (`ON CONFLICT`, `last_insert_rowid()`).
+3. Data migration helper (#108) – PENDING.
+4. Documentation expansion (#109) – PENDING.
 
-Until #107 is complete, selecting `SqlServer` will likely fail on operations relying on SQLite-only constructs. Use SQLite unless you are actively contributing to the provider work.
+Implementation notes (#106):
+- A new `ISchemaInitializer` is registered based on `Database:Provider` and invoked during startup (API & Frontend host).
+- `SqliteSchemaInitializer` contains the former static DDL logic (transactional create-if-not-exists).
+- `SqlServerSchemaInitializer` currently provisions an equivalent schema (tables, PKs, FKs, indexes) using `IF NOT EXISTS` guards; still experimental.
+- Repositories & Razor Pages continue to use some SQLite-specific syntax; selecting SQL Server may hit unsupported paths until #107 refactors queries.
+
+Until #107 is complete, selecting `SqlServer` may fail on operations relying on SQLite-only constructs. Use SQLite unless you are actively contributing to the provider work.
 
 — “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson
 

--- a/ReceptRegister.Api/Data/ISchemaInitializer.cs
+++ b/ReceptRegister.Api/Data/ISchemaInitializer.cs
@@ -1,0 +1,6 @@
+namespace ReceptRegister.Api.Data;
+
+public interface ISchemaInitializer
+{
+    Task InitializeAsync(CancellationToken ct = default);
+}

--- a/ReceptRegister.Api/Data/SqlServerSchemaInitializer.cs
+++ b/ReceptRegister.Api/Data/SqlServerSchemaInitializer.cs
@@ -1,0 +1,88 @@
+namespace ReceptRegister.Api.Data;
+
+public sealed class SqlServerSchemaInitializer : ISchemaInitializer
+{
+    private readonly IDbConnectionFactory _factory;
+    private readonly ILogger<SqlServerSchemaInitializer> _logger;
+    public SqlServerSchemaInitializer(IDbConnectionFactory factory, ILogger<SqlServerSchemaInitializer> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        // NOTE: This is a first pass placeholder. Full parity (constraints, cascades, indexes) will be refined in #107.
+        _logger.LogDebug("Initializing SQL Server schema (experimental)...");
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        await using var tx = await conn.BeginTransactionAsync(ct);
+
+        var commands = new[]
+        {
+            @"IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Recipes') BEGIN
+                CREATE TABLE dbo.Recipes (
+                    Id INT IDENTITY(1,1) PRIMARY KEY,
+                    Name NVARCHAR(400) NOT NULL,
+                    Book NVARCHAR(400) NOT NULL,
+                    Page INT NOT NULL,
+                    Notes NVARCHAR(MAX) NULL,
+                    Tried BIT NOT NULL DEFAULT 0
+                );
+            END",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'AuthConfig') BEGIN
+                CREATE TABLE dbo.AuthConfig (
+                    Id INT NOT NULL CONSTRAINT PK_AuthConfig PRIMARY KEY,
+                    PasswordHash VARBINARY(512) NOT NULL,
+                    Salt VARBINARY(256) NOT NULL,
+                    Iterations INT NOT NULL,
+                    CreatedAt DATETIMEOFFSET NOT NULL,
+                    UpdatedAt DATETIMEOFFSET NOT NULL
+                );
+            END",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Categories') BEGIN
+                CREATE TABLE dbo.Categories (
+                    Id INT IDENTITY(1,1) PRIMARY KEY,
+                    Name NVARCHAR(200) NOT NULL UNIQUE
+                );
+            END",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'Keywords') BEGIN
+                CREATE TABLE dbo.Keywords (
+                    Id INT IDENTITY(1,1) PRIMARY KEY,
+                    Name NVARCHAR(200) NOT NULL UNIQUE
+                );
+            END",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'RecipeCategories') BEGIN
+                CREATE TABLE dbo.RecipeCategories (
+                    RecipeId INT NOT NULL,
+                    CategoryId INT NOT NULL,
+                    CONSTRAINT PK_RecipeCategories PRIMARY KEY (RecipeId, CategoryId),
+                    CONSTRAINT FK_RecipeCategories_Recipes FOREIGN KEY (RecipeId) REFERENCES dbo.Recipes(Id) ON DELETE CASCADE,
+                    CONSTRAINT FK_RecipeCategories_Categories FOREIGN KEY (CategoryId) REFERENCES dbo.Categories(Id) ON DELETE CASCADE
+                );
+            END",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.tables WHERE name = 'RecipeKeywords') BEGIN
+                CREATE TABLE dbo.RecipeKeywords (
+                    RecipeId INT NOT NULL,
+                    KeywordId INT NOT NULL,
+                    CONSTRAINT PK_RecipeKeywords PRIMARY KEY (RecipeId, KeywordId),
+                    CONSTRAINT FK_RecipeKeywords_Recipes FOREIGN KEY (RecipeId) REFERENCES dbo.Recipes(Id) ON DELETE CASCADE,
+                    CONSTRAINT FK_RecipeKeywords_Keywords FOREIGN KEY (KeywordId) REFERENCES dbo.Keywords(Id) ON DELETE CASCADE
+                );
+            END",
+            // Indexes
+            @"IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='IX_Recipes_Name') CREATE INDEX IX_Recipes_Name ON dbo.Recipes(Name);",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='IX_Categories_Name') CREATE INDEX IX_Categories_Name ON dbo.Categories(Name);",
+            @"IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name='IX_Keywords_Name') CREATE INDEX IX_Keywords_Name ON dbo.Keywords(Name);"
+        };
+
+        foreach (var sql in commands)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+        await tx.CommitAsync(ct);
+        _logger.LogDebug("SQL Server schema initialization complete (experimental).");
+    }
+}

--- a/ReceptRegister.Api/Data/SqliteSchemaInitializer.cs
+++ b/ReceptRegister.Api/Data/SqliteSchemaInitializer.cs
@@ -1,0 +1,77 @@
+using System.Data.Common;
+
+namespace ReceptRegister.Api.Data;
+
+public sealed class SqliteSchemaInitializer : ISchemaInitializer
+{
+    private readonly IDbConnectionFactory _factory;
+    private readonly ILogger<SqliteSchemaInitializer> _logger;
+    public SqliteSchemaInitializer(IDbConnectionFactory factory, ILogger<SqliteSchemaInitializer> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task InitializeAsync(CancellationToken ct = default)
+    {
+        _logger.LogDebug("Initializing SQLite schema...");
+        await using var conn = _factory.Create();
+        await conn.OpenAsync(ct);
+        await using var tx = await conn.BeginTransactionAsync(ct);
+
+        var commands = new[]
+        {
+            @"CREATE TABLE IF NOT EXISTS Recipes (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL,
+                Book TEXT NOT NULL,
+                Page INTEGER NOT NULL,
+                Notes TEXT NULL,
+                Tried INTEGER NOT NULL DEFAULT 0
+            );",
+            @"CREATE TABLE IF NOT EXISTS AuthConfig (
+                Id INTEGER PRIMARY KEY CHECK (Id = 1),
+                PasswordHash BLOB NOT NULL,
+                Salt BLOB NOT NULL,
+                Iterations INTEGER NOT NULL,
+                CreatedAt TEXT NOT NULL,
+                UpdatedAt TEXT NOT NULL
+            );",
+            @"CREATE TABLE IF NOT EXISTS Categories (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL UNIQUE
+            );",
+            @"CREATE TABLE IF NOT EXISTS Keywords (
+                Id INTEGER PRIMARY KEY AUTOINCREMENT,
+                Name TEXT NOT NULL UNIQUE
+            );",
+            @"CREATE TABLE IF NOT EXISTS RecipeCategories (
+                RecipeId INTEGER NOT NULL,
+                CategoryId INTEGER NOT NULL,
+                PRIMARY KEY (RecipeId, CategoryId),
+                FOREIGN KEY (RecipeId) REFERENCES Recipes(Id) ON DELETE CASCADE,
+                FOREIGN KEY (CategoryId) REFERENCES Categories(Id) ON DELETE CASCADE
+            );",
+            @"CREATE TABLE IF NOT EXISTS RecipeKeywords (
+                RecipeId INTEGER NOT NULL,
+                KeywordId INTEGER NOT NULL,
+                PRIMARY KEY (RecipeId, KeywordId),
+                FOREIGN KEY (RecipeId) REFERENCES Recipes(Id) ON DELETE CASCADE,
+                FOREIGN KEY (KeywordId) REFERENCES Keywords(Id) ON DELETE CASCADE
+            );",
+            "CREATE INDEX IF NOT EXISTS IX_Recipes_Name ON Recipes(Name);",
+            "CREATE INDEX IF NOT EXISTS IX_Categories_Name ON Categories(Name);",
+            "CREATE INDEX IF NOT EXISTS IX_Keywords_Name ON Keywords(Name);"
+        };
+
+        foreach (var sql in commands)
+        {
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText = sql;
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        await tx.CommitAsync(ct);
+        _logger.LogDebug("SQLite schema initialization complete.");
+    }
+}

--- a/ReceptRegister.Api/Program.cs
+++ b/ReceptRegister.Api/Program.cs
@@ -11,8 +11,8 @@ builder.Services.AddAuthServices();
 
 var app = builder.Build();
 
-// Ensure database schema exists (tables created) before handling requests
-await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<IDbConnectionFactory>());
+// Ensure database schema exists (tables created) before handling requests (provider-specific)
+await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
 
 app.UseAuthSession();
 app.MapApiEndpoints();

--- a/ReceptRegister.Frontend/Program.cs
+++ b/ReceptRegister.Frontend/Program.cs
@@ -27,8 +27,8 @@ if (!app.Environment.IsDevelopment())
 
 app.UseRouting();
 
-// Ensure DB schema exists for shared API endpoints (recipes, auth, taxonomy)
-await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<ISqliteConnectionFactory>());
+// Ensure DB schema exists for shared API endpoints (recipes, auth, taxonomy) using provider abstraction
+await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
 // Auth session (cookie + csrf) before endpoints
 app.UseAuthSession();
 

--- a/ReceptRegister.Tests/AuthEndpointsTests.cs
+++ b/ReceptRegister.Tests/AuthEndpointsTests.cs
@@ -34,7 +34,7 @@ public class AuthEndpointsTests
         var app = builder.Build();
         app.UseAuthSession();
         app.MapApiEndpoints();
-        await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<ISqliteConnectionFactory>());
+    await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
         await app.StartAsync();
         var handler = new HttpClientHandler { UseCookies = true, CookieContainer = new System.Net.CookieContainer() };
         var client = new HttpClient(handler) { BaseAddress = new Uri(app.Urls.First()) };

--- a/ReceptRegister.Tests/AuthRoundtripTests.cs
+++ b/ReceptRegister.Tests/AuthRoundtripTests.cs
@@ -32,7 +32,7 @@ public class AuthRoundtripTests
         var app = builder.Build();
     app.UseAuthSession();
     app.MapApiEndpoints();
-        await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<ISqliteConnectionFactory>());
+    await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
         await app.StartAsync();
     var handler = new HttpClientHandler { UseCookies = true, CookieContainer = new System.Net.CookieContainer() };
     var client = new HttpClient(handler) { BaseAddress = new Uri(app.Urls.First()) };

--- a/ReceptRegister.Tests/FrontendPagesTests.cs
+++ b/ReceptRegister.Tests/FrontendPagesTests.cs
@@ -33,7 +33,7 @@ public class FrontendPagesTests : IDisposable
     var app = builder.Build();
     // Fresh database will be created under the unique content root
         app.MapRazorPages();
-        await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<ISqliteConnectionFactory>());
+    await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
         await app.StartAsync();
         return app.GetTestClient();
     }

--- a/ReceptRegister.Tests/LoginPageTests.cs
+++ b/ReceptRegister.Tests/LoginPageTests.cs
@@ -29,7 +29,7 @@ public class LoginPageTests
         var app = builder.Build();
     // Fresh DB under unique content root
         app.MapRazorPages();
-        await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<ISqliteConnectionFactory>());
+    await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
     await app.StartAsync();
     return app.GetTestClient();
     }

--- a/ReceptRegister.Tests/PasswordServiceTests.cs
+++ b/ReceptRegister.Tests/PasswordServiceTests.cs
@@ -27,10 +27,10 @@ public class PasswordServiceTests
 
         // Persistence / auth infra
     var factory = existingPath is null ? new TestSqliteFactory() : new TestSqliteFactory(existingPath);
-    services.AddSingleton<ISqliteConnectionFactory>(factory);
+    services.AddSingleton<IDbConnectionFactory>(factory);
         services.AddAuthServices();
         var sp = services.BuildServiceProvider();
-        await SchemaInitializer.InitializeAsync(sp.GetRequiredService<ISqliteConnectionFactory>());
+    await sp.GetRequiredService<ISchemaInitializer>().InitializeAsync();
     return (sp.GetRequiredService<IPasswordService>(), factory.Path);
     }
 
@@ -66,7 +66,7 @@ internal sealed class FakeEnvAuth : IWebHostEnvironment
     public IFileProvider WebRootFileProvider { get; set; } = new NullFileProvider();
 }
 
-internal class TestSqliteFactory : ISqliteConnectionFactory
+internal class TestSqliteFactory : IDbConnectionFactory
 {
     public string Path { get; }
     public TestSqliteFactory() : this(System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"auth-{Guid.NewGuid():N}.db")) {}

--- a/ReceptRegister.Tests/RecipeRepositoryTests.cs
+++ b/ReceptRegister.Tests/RecipeRepositoryTests.cs
@@ -4,7 +4,7 @@ using Microsoft.Data.Sqlite;
 
 namespace ReceptRegister.Tests;
 
-public class TempConnectionFactory : ISqliteConnectionFactory
+public class TempConnectionFactory : IDbConnectionFactory
 {
     private readonly string _cs;
     public TempConnectionFactory()
@@ -20,7 +20,8 @@ public class RecipeRepositoryTests
     private async Task<(IRecipesRepository recipes, ITaxonomyRepository taxonomy)> CreateReposAsync()
     {
         var factory = new TempConnectionFactory();
-        await SchemaInitializer.InitializeAsync(factory);
+    var initializer = new SqliteSchemaInitializer(factory, NullLogger<SqliteSchemaInitializer>.Instance);
+    await initializer.InitializeAsync();
         return (new RecipesRepository(factory), new TaxonomyRepository(factory));
     }
 

--- a/ReceptRegister.Tests/SetPasswordPageTests.cs
+++ b/ReceptRegister.Tests/SetPasswordPageTests.cs
@@ -28,7 +28,7 @@ public class SetPasswordPageTests
         var app = builder.Build();
     // Fresh DB under unique content root
         app.MapRazorPages();
-        await SchemaInitializer.InitializeAsync(app.Services.GetRequiredService<ISqliteConnectionFactory>());
+    await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
     await app.StartAsync();
     var client = app.GetTestClient();
 


### PR DESCRIPTION
Implements issue #106 (Epic #110) by introducing provider-specific schema initialization.

Key changes:
- Added ISchemaInitializer interface with two implementations: SqliteSchemaInitializer (migrated existing DDL) and experimental SqlServerSchemaInitializer.
- Updated DI to register the appropriate initializer based on Database:Provider.
- Startup (API & Frontend) now resolves and invokes ISchemaInitializer instead of calling a static helper.
- Removed the old static SchemaInitializer and any ISqliteConnectionFactory references (fully converged on IDbConnectionFactory).
- Refactored Razor Page models and tests to use the abstraction; added parameter creation without AddWithValue for provider neutrality.
- README updated: marks #106 as DONE and documents the new abstraction and current limitations (#107 pending for query dialect neutrality).

Notes / Limitations:
- Repositories still use SQLite-specific constructs (ON CONFLICT, last_insert_rowid()); SQL Server operations that hit these paths will fail until #107.
- SqlServerSchemaInitializer is a first-pass schema; further refinement (data types, constraints parity, potential migrations) slated for #107/#108.

Next steps (separate PRs):
1. Neutralize repository SQL & introduce provider-aware helpers (#107).
2. Add migration / upgrade tooling (#108).
3. Expand docs to include SQL Server operational guidance (#109).

Testing:
- All tests updated to use ISchemaInitializer; local compilation succeeded.

Please review focusing on:
- DI registration safety (singleton initializer resolution).
- Any missed references to removed static initializer.
- README clarity for contributors.

Thanks!