### PR TITLE
Docs: Azure SQL quickstart, troubleshooting, and roadmap (Closes #109)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Security reminders:
 | `Cannot open server requested by the login` | Wrong server or database name | Verify `Server=` and `Initial Catalog=` values |
 | `Client with IP address ... is not allowed to access the server` | Firewall rule missing | Add client IP in server Networking settings |
 | Long first query (~5-15s) | Serverless database resumed | Expected; subsequent queries faster |
-| `Certificate chain was issued by an authority that is not trusted` (local dev) | Older dev machine certificates store | Keep `Encrypt=True;TrustServerCertificate=False`; ensure OS root certs updated (Windows Update). Avoid disabling encryption |
+| `Certificate chain was issued by an authority that is not trusted` (local dev) | Older dev machine certificate store | Keep `Encrypt=True;TrustServerCertificate=False`; ensure OS root certs updated (Windows Update). Avoid disabling encryption |
 | Migration tool very slow | High network latency + many round trips | (Future) Batch insert enhancement (#118/#120); for now run from a machine in same region |
 
 ### Roadmap / follow-ups

--- a/README.md
+++ b/README.md
@@ -222,6 +222,59 @@ After migration:
 - Visit the site; you will be in setup mode (no password) unless you manually migrated AuthConfig which is intentionally not handled.
 - Set a new password and verify recipes appear.
 
+### Azure SQL quickstart (experimental provider)
+
+You can point the application at an Azure SQL Database (recommended for a small personal deployment: serverless, basic tier). These steps assume you already have an Azure subscription.
+
+1. Create resource (Portal):
+	- Search "Azure SQL" -> "Create" -> "SQL database".
+	- Select (or create) a logical server. For low-cost dev, choose serverless compute if available; basic tiers are also fine (recipe index is small).
+	- Enable "Allow Azure services and resources to access this server" during creation (simplifies firewall).
+2. Networking / firewall:
+	- Add your current client IP so you can connect initially. (Or later, configure a private endpoint / specific IP range.)
+3. Authentication:
+	- Use SQL auth with a strong admin password (store it in a password manager). Azure AD auth is possible but not documented here.
+4. Connection string:
+	- After provisioning, go to the database -> "Connection strings" -> copy the ADO.NET connection string. It looks like: `Server=tcp:<servername>.database.windows.net,1433;Initial Catalog=<dbname>;Persist Security Info=False;User ID=<user>;Password=<pw>;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;`
+	- DO NOT commit this; store in environment variable or user secrets.
+5. App configuration:
+	- Set `Database:Provider=SqlServer`.
+	- Set `Database:ConnectionString` to the copied string (ideally via environment variable, e.g. `RECEPTREGISTER__Database__ConnectionString`).
+6. First run:
+	- Start the application; schema will auto-create. Confirm logs show `SqlServerSchemaInitializer` ran.
+7. (Optional) Migrate existing local SQLite data:
+	- Run migration mode: `dotnet run --project ReceptRegister.Api -- --migrate-sqlite="C:\\path\\to\\receptregister.db"` then start normally.
+
+Cost & performance notes:
+- Serverless Azure SQL can pause; expect a cold-start latency (several seconds) on first query after idle period.
+- For extremely low usage you might still prefer file-based SQLite to avoid hosting cost entirely.
+- The application issues light, parameterized queries; the Basic / S0 tier should be ample.
+
+Security reminders:
+- Always use `Encrypt=True;TrustServerCertificate=False` (default from portal) to enforce TLS.
+- Restrict firewall to only the hosts that need access (App Service, your IP, etc.).
+- Never commit the connection string; prefer environment injection / Azure configuration.
+
+### Azure SQL troubleshooting
+
+| Symptom | Cause | Suggested fix |
+|---------|-------|---------------|
+| `Login failed for user` | Wrong username or password | Regenerate password in portal; update env variable |
+| `Cannot open server requested by the login` | Wrong server or database name | Verify `Server=` and `Initial Catalog=` values |
+| `Client with IP address ... is not allowed to access the server` | Firewall rule missing | Add client IP in server Networking settings |
+| Long first query (~5-15s) | Serverless database resumed | Expected; subsequent queries faster |
+| `Certificate chain was issued by an authority that is not trusted` (local dev) | Older dev machine certificates store | Keep `Encrypt=True;TrustServerCertificate=False`; ensure OS root certs updated (Windows Update). Avoid disabling encryption |
+| Migration tool very slow | High network latency + many round trips | (Future) Batch insert enhancement (#118/#120); for now run from a machine in same region |
+
+### Roadmap / follow-ups
+
+The initial migration and dual-provider work is complete; enhancements tracked separately:
+- #118: SQL Server integration test for `DataMigrationRunner`.
+- #119: Optional AuthConfig (password hash) migration flag.
+- #120: Dry-run / summary mode for migration.
+
+These are not required for basic SQL Server usage; they refine reliability & UX.
+
 
 — “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson
 


### PR DESCRIPTION
Adds Azure SQL provider documentation to README:

Changes:
- Azure SQL quickstart (provision, firewall, connection string, config)
- Troubleshooting table (common errors + resolutions)
- Cost/performance & security notes
- Roadmap section referencing #118 [no-close] #119 [no-close] #120 [no-close] for follow-up enhancements

Issue Linkages:
Closes #109

Notes:
- Pure docs change; no code or tests affected.
- Squash merge acceptable; single commit already clean.
- No dependency or config changes.

Validation:
- Local build/test run prior to branch creation (all green).

Rationale for [no-close] tags: enhancement issues are intentionally left open for future improvements and should not auto-close with these base docs.