### PR TITLE
Promote main -> release/preview-2 (include .NET 10 workflow change)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   PROJECT_PATH: 'ReceptRegister.Frontend/ReceptRegister.Frontend.csproj'
   PUBLISH_DIR: 'publish'
   BUILD_CONFIG: 'Release'
@@ -48,11 +48,12 @@ jobs:
         run: dotnet test ReceptRegister.Tests/ReceptRegister.Tests.csproj -c $BUILD_CONFIG --no-build --logger "trx;LogFileName=test-results.trx"
 
       - name: Publish
-        if: ${{ github.event_name != 'pull_request' || github.event.inputs.dry_run != 'true' }}
+        # Publish only for push events (release branch) or manual dispatch when not a dry_run.
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
         run: dotnet publish ${{ env.PROJECT_PATH }} -c $BUILD_CONFIG -o $PUBLISH_DIR /p:PublishSingleFile=false
 
       - name: Upload Artifact
-        if: ${{ github.event_name != 'pull_request' || github.event.inputs.dry_run != 'true' }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
         uses: actions/upload-artifact@v4
         with:
           name: release-drop
@@ -62,6 +63,7 @@ jobs:
     name: Deploy
     needs: build-test
     runs-on: ubuntu-latest
+    # Deploy only on push (never on PR or manual dispatch) and inherently not a dry_run path.
     if: ${{ github.event_name == 'push' && github.event.inputs.dry_run != 'true' }}
     steps:
       - name: Download Artifact

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100-preview.4",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Promotes the latest changes from main into release/preview-2.

Included commit(s):
- 881aa1c ci: target .NET 10 preview with global.json (#126)

Release branch currently contains CHANGELOG updates (preview-2 tag) not on main, so this keeps history flowing one-way (main ahead by .NET 10 workflow, release ahead by docs). After merge, consider tagging preview-3 if you intend the .NET 10 support to be part of a new preview cut.

Next steps after merge:
1. Push merge to release/preview-2 (auto via merge).
2. Allow the release workflow to build & (on push) deploy.
3. Verify health endpoint passes.

If build fails due to SDK availability, adjust global.json / DOTNET_VERSION accordingly.
