### PR TITLE
build: exclude API appsettings from publish to avoid duplicate file collision

### DIFF
--- a/ReceptRegister.Api/ReceptRegister.Api.csproj
+++ b/ReceptRegister.Api/ReceptRegister.Api.csproj
@@ -11,4 +11,11 @@
   <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>
 
+  <!-- Prevent duplicate appsettings*.json collisions when this project is referenced by Frontend during publish.
+       Configuration is supplied by the hosting (Frontend) project, so we do not need to copy these files from the API assembly. -->
+  <ItemGroup>
+    <Content Update="appsettings.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+    <Content Update="appsettings.Development.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This PR excludes the API project's appsettings.json and appsettings.Development.json from publish output when referenced by the Frontend host. This prevents the earlier release workflow failure:

> Found multiple publish output files with the same relative path: appsettings.json

Rationale:
- The Frontend is the hosting project; its configuration should win.
- The API functions as a referenced project; duplicating its config causes a collision during dotnet publish.

Change summary:
- Added <Content Update="appsettings*.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" /> entries in ReceptRegister.Api.csproj.

Impact:
- Eliminates publish-time duplicate file collision.
- No runtime impact: configuration is still loaded from the hosting project's appsettings files.

After merge:
- Re-run release branch promotion (main -> release/preview-2) to validate publish & deployment succeed.

Let me know if you'd prefer to instead transform filenames or consolidate config another way.