### PR TITLE
ci: exclude API appsettings from publish & switch deploy workflow to ReceptRegister environment OIDC

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -61,10 +61,12 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: build-test
-    runs-on: ubuntu-latest
-    # Deploy only on push (never on PR or manual dispatch) and inherently not a dry_run path.
+    needs: [build-test]
     if: ${{ github.event_name == 'push' && github.event.inputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    # GitHub Environment enables a single federated credential (subject: repo:crswebb/ReceptRegister:environment:ReceptRegister)
+    environment:
+      name: ReceptRegister
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary
This PR does two related CI/CD hardening changes:
1. Prevents duplicate/conflicting `appsettings*.json` from the API project being copied into the published frontend output.
2. Updates the release deployment workflow to use the GitHub Environment `ReceptRegister` (environment‑scoped OIDC subject) instead of a branch-based subject, simplifying federated credential management.

## Why
- The publish build previously failed due to file name collisions when both Frontend and API configs landed in the same output.
- Moving to an environment-based OIDC subject future-proofs identity: one federated credential covers all release/* branches, reducing maintenance and minimizing risk of misconfiguration.

## Changes
- `.github/workflows/release-deploy.yml`
  - Added `environment: ReceptRegister` to the deploy job.
  - Adjusted comment to reflect new OIDC subject: `repo:crswebb/ReceptRegister:environment:ReceptRegister`.
- `ReceptRegister.Api.csproj` (earlier commit already on this branch)
  - Excludes `appsettings*.json` from being published when API is only referenced by the frontend publish, removing duplicate content.

## OIDC / Azure Impact
- Requires a federated credential in Entra App `receptregister-deploy` with subject:
  `repo:crswebb/ReceptRegister:environment:ReceptRegister`
- After this PR merges (and promotion to a release/* branch), deployments will use the environment trust.
- Old branch-specific federated credentials can be removed after first successful deploy.

## Validation Performed
- Workflow YAML validates locally (structure: two jobs, `needs: [build-test]`, deploy gated by push to release/*).
- Build logic unchanged except for environment association.
- Artifact handoff (upload/download) unaffected.
- No runtime code changes; only CI and publish content behavior.

## How to Roll Out
1. Merge this PR to `main`.
2. Promote `main` → `release/preview-2` (or create `release/preview-3`).
3. Ensure federated credential exists before the release branch push.
4. Watch the `azure/login` step; success confirms subject match.

## Follow-Up (Optional)
- Move Azure secrets into the `ReceptRegister` GitHub Environment for tighter scope.
- Add required reviewers / wait timer on the environment for gated deploys.
- Add NuGet caching step to speed builds.
- Tag `preview-3` and update CHANGELOG to record the environment-based OIDC shift.

## Security Considerations
- Eliminates need for per-branch federated credentials (smaller attack surface).
- Still no client secret stored (pure OIDC).
- Encourages environment-scoped secrets (next step).

## Testing Notes
No functional app changes; primary risk is mis-typed environment name or missing federated credential. If deploy fails with AADSTS700213, re-check subject & case-sensitivity.

## Checklist
- [ ] Federated credential created in Entra
- [ ] (Optional) Environment secrets configured
- [ ] Promotion PR opened after merge
- [ ] First deployment succeeds
- [ ] Old federated credentials removed (optional cleanup)
