### PR TITLE
chore: promote main to release/preview-2 (environment OIDC + publish fix)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -20,7 +20,7 @@ permissions:
   pull-requests: read
 
 env:
-  DOTNET_VERSION: '8.0.x'
+  DOTNET_VERSION: '10.0.x'
   PROJECT_PATH: 'ReceptRegister.Frontend/ReceptRegister.Frontend.csproj'
   PUBLISH_DIR: 'publish'
   BUILD_CONFIG: 'Release'
@@ -48,11 +48,12 @@ jobs:
         run: dotnet test ReceptRegister.Tests/ReceptRegister.Tests.csproj -c $BUILD_CONFIG --no-build --logger "trx;LogFileName=test-results.trx"
 
       - name: Publish
-        if: ${{ github.event_name != 'pull_request' || github.event.inputs.dry_run != 'true' }}
+        # Publish only for push events (release branch) or manual dispatch when not a dry_run.
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
         run: dotnet publish ${{ env.PROJECT_PATH }} -c $BUILD_CONFIG -o $PUBLISH_DIR /p:PublishSingleFile=false
 
       - name: Upload Artifact
-        if: ${{ github.event_name != 'pull_request' || github.event.inputs.dry_run != 'true' }}
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
         uses: actions/upload-artifact@v4
         with:
           name: release-drop
@@ -62,6 +63,7 @@ jobs:
     name: Deploy
     needs: build-test
     runs-on: ubuntu-latest
+    # Deploy only on push (never on PR or manual dispatch) and inherently not a dry_run path.
     if: ${{ github.event_name == 'push' && github.event.inputs.dry_run != 'true' }}
     steps:
       - name: Download Artifact

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -61,10 +61,12 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: build-test
-    runs-on: ubuntu-latest
-    # Deploy only on push (never on PR or manual dispatch) and inherently not a dry_run path.
+    needs: [build-test]
     if: ${{ github.event_name == 'push' && github.event.inputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    # GitHub Environment enables a single federated credential (subject: repo:crswebb/ReceptRegister:environment:ReceptRegister)
+    environment:
+      name: ReceptRegister
     steps:
       - name: Download Artifact
         uses: actions/download-artifact@v4

--- a/ReceptRegister.Api/ReceptRegister.Api.csproj
+++ b/ReceptRegister.Api/ReceptRegister.Api.csproj
@@ -11,4 +11,11 @@
   <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
   </ItemGroup>
 
+  <!-- Prevent duplicate appsettings*.json collisions when this project is referenced by Frontend during publish.
+       Configuration is supplied by the hosting (Frontend) project, so we do not need to copy these files from the API assembly. -->
+  <ItemGroup>
+    <Content Update="appsettings.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+    <Content Update="appsettings.Development.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" />
+  </ItemGroup>
+
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100-preview.4",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## Promotion: main → release/preview-2

Promoting latest changes from `main` into the `release/preview-2` branch for deployment.

### Included Highlights
- Environment-scoped OIDC for deploy workflow (`ReceptRegister` environment) enabling single federated credential.
- Exclusion of API `appsettings*.json` from frontend publish output (removes duplicate config collisions).

### Deployment Expectations
On merge, a push to `release/preview-2` will trigger the `Release Build & Deploy` workflow:
1. Build & test
2. Publish & artifact upload
3. Deploy job (uses environment `ReceptRegister`) via `azure/login` OIDC
4. Smoke health probe at `/health`

### Pre-merge Checklist
- [ ] Federated credential exists in Entra App `receptregister-deploy` with subject `repo:crswebb/ReceptRegister:environment:ReceptRegister`
- [ ] Azure secrets present (repo or environment scope): `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`, `AZURE_WEBAPP_NAME`, `AZURE_WEBAPP_HOST`

### Post-merge Verification
- Watch `azure/login` step for success (no AADSTS700213)
- Confirm health probe passes (HTTP 200)
- Optional: tag `preview-3` if we want to differentiate environment-OIDC change

### Rollback Plan
If deployment fails due to OIDC: re-create / correct federated credential subject, re-run workflow. No application code change included—safe to re-promote.

---
Merging this PR will deploy the updated pipeline logic. Proceed when checklist items are satisfied.
