### PR TITLE
chore: back-merge release/preview-2 into main (deploy workflow & self-contained publish)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -50,7 +50,17 @@ jobs:
       - name: Publish
         # Publish only for push events (release branch) or manual dispatch when not a dry_run.
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
-        run: dotnet publish ${{ env.PROJECT_PATH }} -c $BUILD_CONFIG -o $PUBLISH_DIR /p:PublishSingleFile=false
+        run: |
+          echo "Publishing self-contained linux-x64 (App Service lacks preview shared runtime)"
+          dotnet publish ${{ env.PROJECT_PATH }} -c $BUILD_CONFIG -r linux-x64 --self-contained true -o $PUBLISH_DIR /p:PublishSingleFile=false
+
+      - name: Publish Diagnostics
+        if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
+        run: |
+          echo "Listing publish output:";
+          find $PUBLISH_DIR -maxdepth 1 -type f -printf '%f\n' | sort | head -n 40;
+          echo "dotnet --info (build runner):";
+          dotnet --info
 
       - name: Upload Artifact
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
@@ -90,14 +100,19 @@ jobs:
       - name: Smoke Test
         run: |
           set -e
-          URL="https://${{ secrets.AZURE_WEBAPP_HOST }}/health"
-          echo "Probing $URL";
+          BASE="https://${{ secrets.AZURE_WEBAPP_HOST }}"
+          PATHS="/api/health /health"
+          echo "Probing health endpoints ($PATHS) at $BASE";
           for i in {1..5}; do
-            STATUS=$(curl -sk -o /dev/null -w '%{http_code}' "$URL" || true)
-            if [ "$STATUS" = "200" ]; then echo "Health OK"; exit 0; fi
-            echo "Attempt $i failed status=$STATUS"; sleep 5;
+            for P in $PATHS; do
+              URL="$BASE$P"
+              STATUS=$(curl -sk -o /dev/null -w '%{http_code}' "$URL" || true)
+              echo "Attempt $i $P -> $STATUS"
+              if [ "$STATUS" = "200" ]; then echo "Health OK via $P"; exit 0; fi
+            done
+            sleep 5;
           done
-          echo "Health check failed"; exit 1
+          echo "Health check failed (paths tried: $PATHS)"; exit 1
 
       - name: Summary
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format loosely follows Keep a Changelog, with unreleased changes collected under the `[Unreleased]` section. Versions / previews are cut from `main` into `release/*` branches.
+
+## [Unreleased]
+- (placeholder)
+
+## [preview-2] - 2025-08-30
+### Added
+- Release workflow: build & test on PRs to `release/**`; publish & deploy only on push (policy codified in #124).
+- Changelog file introduced.
+
+### Changed
+- README sanitized: removed instance-specific deployment details; added neutral deployment note (#125).
+
+### Removed
+- Azure instance-specific instructions from README (moved to neutral guidance).
+
+### Security
+- No security-affecting changes.
+
+## [preview-1] - 2025-08-22
+### Added
+- Initial preview scaffolding and baseline features (see commit history prior to `preview-2`).
+
+[Unreleased]: https://github.com/crswebb/ReceptRegister/compare/release/preview-2...HEAD
+[preview-2]: https://github.com/crswebb/ReceptRegister/compare/release/preview-1...release/preview-2


### PR DESCRIPTION
## Back-Merge: release/preview-2 → main

Synchronizing `main` with improvements that landed directly (or only) on `release/preview-2` during deployment hardening.

### Included Changes
- Self-contained linux-x64 publish for .NET 10 preview (ensures runtime present on App Service).
- Enhanced smoke test checking `/api/health` then `/health`.
- Diagnostics step listing publish output and `dotnet --info`.
- Environment-based OIDC deploy workflow already present, ensuring consistent identity configuration.

### Rationale
Keeping `main` behind the release branch would cause future noisy promotions and potential conflicts. This merge aligns histories so future release promotions are delta-only on application changes.

### Conflict Resolution
Resolved `.github/workflows/release-deploy.yml` by retaining the self-contained publish & diagnostics from `release/preview-2`.

### Verification
- Prior release deployments succeeded in build & deploy steps (health probe was fixed by endpoint update and runtime packaging adjustments).
- No application code logic altered; only CI/CD pipeline behavior.

### Next Steps After Merge
1. Continue feature work off updated `main`.
2. When .NET 10 is GA, consider reverting to framework-dependent publish (remove `--self-contained true -r linux-x64`).
3. Optionally add NuGet cache and environment-scoped secrets if not already done.

### Safety / Rollback
If any unexpected issue arises, workflow can be rolled back by reverting this commit; runtime packaging change only affects deployment, not code semantics.

---
Merge when ready to keep branches aligned.
