### PR TITLE
ci: sync release workflow & gitignore from release/preview-3 (#140)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -62,7 +62,8 @@ jobs:
           echo "dotnet --info (build runner):";
           dotnet --info
 
-      - name: Guard: Single runtimeconfig
+      - name: Runtimeconfig guard
+        id: runtimeconfig_guard
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
         run: |
           set -e

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 **/obj/
 
 # User secrets / local data
+## Local ad-hoc publish output (developer convenience folder, not source)
+/local-publish/
+
 *.db
 *.db-shm
 *.db-wal


### PR DESCRIPTION
Cherry-picks from release/preview-3 to align main:

- f55369e ci: fix yaml syntax for runtimeconfig guard step
- 63476b3 chore(gitignore): ignore local-publish ad-hoc publish output

Rationale:
Keep main authoritative for generic build/test/deploy logic and repository hygiene; eliminate non-release-specific drift living only on the release branch.

Follow-up after merge:
1. Fast-forward release/preview-3 from updated main (promotion PR or fast-forward).
2. Add release push guard workflow to forbid direct commits to release/** (issue #140).

No additional changes beyond:
- .github/workflows/release-deploy.yml
- .gitignore

Closes #140