### PR TITLE
promote: sync main -> release/preview-3 (post #135 alignment)

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -62,7 +62,8 @@ jobs:
           echo "dotnet --info (build runner):";
           dotnet --info
 
-      - name: Guard: Single runtimeconfig
+      - name: Runtimeconfig guard
+        id: runtimeconfig_guard
         if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true') }}
         run: |
           set -e

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 **/obj/
 
 # User secrets / local data
+## Local ad-hoc publish output (developer convenience folder, not source)
+/local-publish/
+
 *.db
 *.db-shm
 *.db-wal


### PR DESCRIPTION
Synchronize release/preview-3 with the latest main after merging PR #135.

Main adds commit bringing workflow + .gitignore updates via a proper PR merge commit:
- e2df6d1 ci: sync release workflow & gitignore from release/preview-3 (#140) (#135)

Release currently contains earlier source commits:
- 774f8b9 docs(changelog): start preview-3 cycle
- 8026100 promote: sync main -> release/preview-3 (api classlib refactor + deploy guard) (#134)
- f55369e ci: fix yaml syntax for runtimeconfig guard step
- 63476b3 chore(gitignore): ignore local-publish ad-hoc publish output

Because branch protection forbids force-push, we cannot rewrite release history to drop the redundant individual commits; instead we accept this merge to ensure the *main* PR merge commit is present on the release branch. Functionally there is no code/content divergence afterward.

Follow-ups:
1. (Optional) Adjust release branch protection to allow force-push by maintainers if strict linear no-merge policy is desired for promotions.
2. Add guard workflow to block future direct pushes to release/** (only promotion PRs allowed).
3. Consider squashing redundant historical commits at the next formal version branch cut, if policy changes.

No file conflicts expected. This PR contains only the merge commit from main.
