### PR TITLE
fix(frontend): separate empty recipes state link text (Closes #138)

### DIFF
--- a/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
+++ b/ReceptRegister.Frontend/Pages/Recipes/Index.cshtml
@@ -73,7 +73,7 @@
 </div>
 @if (Model.Result.TotalItems == 0)
 {
-    <p class="empty">@Html.Raw(L["Page.Recipes.Empty"])</p>
+    <p class="empty">@L["Page.Recipes.Empty"] <a href="/Recipes/Create">@L["Page.Recipes.AddOne"]</a>.</p>
 }
 
 @section Scripts {

--- a/ReceptRegister.Frontend/Resources/SharedResources.resx
+++ b/ReceptRegister.Frontend/Resources/SharedResources.resx
@@ -30,7 +30,8 @@
   <data name="Table.Tried" xml:space="preserve"><value>Tried</value></data>
   <!-- Pages / Headings -->
   <data name="Page.Recipes.Title" xml:space="preserve"><value>Recipes</value></data>
-  <data name="Page.Recipes.Empty" xml:space="preserve"><value>No recipes yet. &lt;a href=\"/Recipes/Create\">Add one&lt;/a>.</value></data>
+  <data name="Page.Recipes.Empty" xml:space="preserve"><value>No recipes yet.</value></data>
+  <data name="Page.Recipes.AddOne" xml:space="preserve"><value>Add one</value></data>
   <data name="Page.CreateRecipe.Title" xml:space="preserve"><value>Add Recipe</value></data>
   <!-- Form Labels / Hints -->
   <data name="Form.Name" xml:space="preserve"><value>Name</value></data>

--- a/ReceptRegister.Frontend/Resources/SharedResources.sv.resx
+++ b/ReceptRegister.Frontend/Resources/SharedResources.sv.resx
@@ -27,7 +27,8 @@
   <data name="Table.Keywords" xml:space="preserve"><value>Nyckelord</value></data>
   <data name="Table.Tried" xml:space="preserve"><value>Testat</value></data>
   <data name="Page.Recipes.Title" xml:space="preserve"><value>Recept</value></data>
-  <data name="Page.Recipes.Empty" xml:space="preserve"><value>Inga recept ännu. &lt;a href=&quot;/Recipes/Create&quot;>Lägg till ett&lt;/a>.</value></data>
+  <data name="Page.Recipes.Empty" xml:space="preserve"><value>Inga recept ännu.</value></data>
+  <data name="Page.Recipes.AddOne" xml:space="preserve"><value>Lägg till ett</value></data>
   <data name="Page.CreateRecipe.Title" xml:space="preserve"><value>Lägg till recept</value></data>
   <data name="Form.Name" xml:space="preserve"><value>Namn</value></data>
   <data name="Form.Name.Help" xml:space="preserve"><value>Primärt visningsnamn för receptet.</value></data>

--- a/ReceptRegister.Tests/FrontendPagesTests.cs
+++ b/ReceptRegister.Tests/FrontendPagesTests.cs
@@ -62,7 +62,10 @@ public class FrontendPagesTests : IDisposable
         var resp = await client.GetAsync("/Recipes/Index");
         resp.EnsureSuccessStatusCode();
         var html = await resp.Content.ReadAsStringAsync();
-        Assert.Contains("No recipes yet", html);
+        Assert.Contains("No recipes yet.", html);
+        Assert.Contains("<a href=\"/Recipes/Create\">Add one</a>.", html);
+        // Ensure the localized pieces are separate and no encoded anchor remnants remain
+        Assert.DoesNotContain("&lt;a href=\"/Recipes/Create\"", html);
     }
 
     [Fact]


### PR DESCRIPTION
Summary:
Separates the empty recipes state sentence and link into two localization keys, removing inline/HTML markup from resource values and composing the anchor directly in the Razor page.

Details:
- Replaced HTML-embedded `Page.Recipes.Empty` resource with plain text sentence.
- Added new key `Page.Recipes.AddOne` (English & Swedish) for the link text.
- Updated `Index.cshtml` to render: `<p>No recipes yet. <a href="/Recipes/Create">Add one</a>.</p>` (localized of course).
- Adjusted `FrontendPagesTests.Recipes_Index_Empty_State` to assert the separated pieces and ensure no encoded or escaped anchor HTML remains in resources.

Rationale:
Keeps translations free of structural HTML, allowing translators to focus on text only and reducing risk of malformed markup or escaping regressions (#138).

Testing:
- Targeted updated test passes locally (`Recipes_Index_Empty_State`).
- Build succeeded.

Issue Linkages:
Closes #138

Risk / Rollback:
Low. If issues arise, revert commit df054c9 and restore prior combined resource string.

Follow-up (optional):
- Add Swedish test variant for empty state.
- Consider lint to detect HTML tags in .resx values where not explicitly allowed.
