### PR TITLE
docs: README restructure & extracted docs (Closes #141 #146 #147 #149 #150 #151 #152 #153 #154)

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -67,3 +67,11 @@ jobs:
             }
 
             core.info('PR policy checks completed.');
+      - name: Advisory README size check
+        run: |
+          echo "README line count:" $(wc -l < README.md)
+          LINES=$(wc -l < README.md)
+          MAX=350
+          if [ "$LINES" -gt "$MAX" ]; then
+            echo "::warning::README has $LINES lines (limit $MAX). Consider extracting content into docs/.";
+          fi

--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -67,11 +67,18 @@ jobs:
             }
 
             core.info('PR policy checks completed.');
+      - name: Checkout repository (for README size check)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Advisory README size check
         run: |
-          echo "README line count:" $(wc -l < README.md)
+          if [ ! -f README.md ]; then
+            echo "::error::README.md not found after checkout"; exit 1;
+          fi
+          echo "README line count: $(wc -l < README.md)"
           LINES=$(wc -l < README.md)
           MAX=350
-          if [ "$LINES" -gt "$MAX" ]; then
-            echo "::warning::README has $LINES lines (limit $MAX). Consider extracting content into docs/.";
-          fi
+            if [ "$LINES" -gt "$MAX" ]; then
+              echo "::warning::README has $LINES lines (limit $MAX). Consider extracting content into docs/.";
+            fi

--- a/README.md
+++ b/README.md
@@ -1,8 +1,56 @@
 # ReceptRegister
 
+> “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson
+
 ReceptRegister is your personal, searchable index for pastry recipes from your book collection. Instead of flipping through sticky notes and indexes, you can find the right recipe in seconds and jump straight to the page.
 
-## What you can store
+## Table of Contents
+1. [Overview](#overview)
+2. [Features](#features)
+	1. [What you can store](#what-you-can-store)
+	2. [What you can do](#what-you-can-do)
+	3. [How it feels](#how-it-feels-to-use)
+	4. [Everyday examples](#everyday-examples)
+	5. [Why it’s helpful](#why-its-helpful)
+3. [Quick Start](#quick-start)
+4. [Security & Access](#security--access)
+	1. [Password hashing & strength](#password-hashing--password-strength)
+	2. [Sessions & authentication endpoints](#sessions--authentication-endpoints)
+	3. [Password recovery & rotation](#password-recovery--rotation)
+	4. [Manual recovery (quick steps)](#manual-recovery-quick-steps)
+5. [Localization](#localization)
+	1. [Overrides (feature #137)](#localization-overrides-feature-137)
+	2. [Fixed culture groundwork](#localization-fixed-culture-groundwork)
+6. [UI / Frontend](#ui--frontend)
+	1. [Mobile friendly menu](#mobile-friendly-menu-feature-139)
+	2. [Theming & design tokens](#theming--design-tokens-ui-polish-milestone)
+7. [Data & Persistence](#data--persistence)
+	1. [Storage (alpha)](#data-storage-early-alpha)
+	2. [Database provider selection](#database-provider-selection-experimental)
+	3. [Data migration](#data-migration-sqlite-to-sql-server)
+8. [API](#api-milestone-4)
+	1. [Core endpoints](#core-endpoints)
+	2. [Query parameters](#query-parameters)
+	3. [Validation & errors](#validation--errors)
+	4. [Tried endpoint change](#tried-endpoint-change)
+9. [Running Locally](#running-locally-milestone-1-scaffolding)
+10. [Publishing](#publishing-self-contained-example)
+11. [Deployment](#deployment-neutral-note)
+12. [Roadmap & Future Ideas](#roadmap--future-ideas)
+13. [Documentation & Maintenance Scripts](#documentation--maintenance-scripts)
+14. [Dependency Policy](#dependency-policy-early-milestones)
+
+---
+
+## Overview
+
+Two apps make up ReceptRegister:
+- API (Minimal API): JSON endpoints & persistence.
+- Frontend (Razor Pages): HTML UI + also (optionally) hosts the API (single-process mode recommended).
+
+## Features
+
+### What you can store
 - Recipe name (e.g., “Kanelbullar”)
 - Book title (which book it comes from)
 - Page number (where to find it in the book)
@@ -10,30 +58,41 @@ ReceptRegister is your personal, searchable index for pastry recipes from your b
 - Keywords (one or more, like “cardamom”, “chocolate”, “gluten-free”)
 - Tried checkbox (mark whether you’ve baked it yet)
 
-## What you can do
+### What you can do
 - Search by name, book, category, or keyword.
 - Quickly see the exact page number in the right book.
 - Filter by “tried” or “not tried” to plan your next bake.
 - Browse by book or category when you’re in the mood for a certain style.
 - Update entries as you explore your library.
- - (API) Query with paging & combined filters (book, category ids, keyword ids, tried) for efficient large libraries.
+- (API) Query with paging & combined filters (book, category ids, keyword ids, tried) for efficient large libraries.
 
-## How it feels to use
+### How it feels to use
 - A simple search bar to find recipes by words you remember.
 - Clear filters for book, category, and tried status.
 - A tidy list showing: Name • Book • Page • Categories • Tried.
 - A focused details view to review and edit a recipe’s information.
 
-## Everyday examples
+### Everyday examples
 - Type “cardamom” to find every recipe with that flavor.
 - Filter by “Buns” to plan a fika spread.
 - Look up “Bröd och Bageri” and jump to page 123.
 - Show only “not tried” recipes to pick your next bake.
 
-## Why it’s helpful
+### Why it’s helpful
 Your shelves stay beautiful, your pages stay clean, and your baking time goes into actual baking—not searching. Think of it as the well‑labeled spice rack for your recipe books.
 
-## Security and access
+## Quick Start
+
+Run the combined frontend (hosts UI + API):
+
+```powershell
+dotnet watch run --project ReceptRegister.Frontend
+```
+Then open the shown localhost URL, set the initial password, and start indexing recipes.
+
+Need separate processes? See [Running Locally](#running-locally-milestone-1-scaffolding).
+
+## Security & access
 - The app is protected with a password.
 - On first visit, if no password has been set yet, you’ll be guided to create one.
 - After that, you’ll sign in before you can use the app.
@@ -57,6 +116,8 @@ If no pepper is configured a warning is logged at startup (safe for local dev). 
 
 Password strength is evaluated server‑side (source of truth) with a 0–6 score (length >=8, length >=12, lowercase, uppercase, digit, symbol). A score of 3+ is required. The client progressively enhances the Set Password UI with a small meter and top suggestions; validation still occurs on the server.
 
+## Localization
+
 ### Localization overrides (feature #137)
 Localization is configured via the `Localization` section in configuration files. You can now override the default and supported cultures using environment variables (takes precedence over config):
 
@@ -74,6 +135,8 @@ $env:RECEPT_SUPPORTED_CULTURES = 'sv-SE,en-US'
 dotnet run --project ReceptRegister.Frontend
 ```
 The application will start with `sv-SE` active and both `sv-SE` / `en-US` registered.
+
+## UI / Frontend
 
 ### Mobile friendly menu (feature #139)
 On small screens (<=700px width) the primary navigation collapses behind a toggle button labeled "Menu" (localized). Tapping the button expands the list in a vertical column; tapping again closes it. The button's accessible state is conveyed via `aria-expanded` and its label changes to "Close menu" when open. On larger viewports the menu is always visible and the toggle is hidden.
@@ -167,14 +230,18 @@ Alternative: you may delete the entire `receptregister.db` file instead (after b
 
 Keep the backup until you confirm the new password works and data (if preserved) is intact.
 
-## Future ideas
+## Roadmap & Future Ideas
+
+### Future ideas
 - Import from a simple spreadsheet to add many recipes at once.
 - Mark favorites or add a quick rating.
 - Add personal notes and tips you discover while baking.
 - Attach photos of results for inspiration.
 - Print or share a shortlist when planning a baking day.
 
-## Data storage (early alpha)
+## Data & Persistence
+
+### Data storage (early alpha)
 The API persists data to a local SQLite file at `App_Data/receptregister.db` (created on first run) by default. (NEW: An experimental SQL Server provider is now selectable – see next section.) Schema is simple:
 - Recipes (Name, Book, Page, Notes, Tried)
 - Categories & Keywords (unique name each, stored lowercase)
@@ -251,7 +318,7 @@ After migration:
 - Visit the site; you will be in setup mode (no password) unless you manually migrated AuthConfig which is intentionally not handled.
 - Set a new password and verify recipes appear.
 
-### Deployment (neutral note)
+## Deployment (neutral note)
 
 This repository does not prescribe a single production deployment path. You can self-host, containerize, or integrate with any managed database / platform you prefer (SQLite file for simplicity, or SQL Server/Azure SQL using the provider abstraction). Each operator is responsible for:
 - Provisioning infrastructure (compute, storage, networking)
@@ -269,8 +336,6 @@ The initial migration and dual-provider work is complete; enhancements tracked s
 - #120: Dry-run / summary mode for migration.
 
 These are not required for basic SQL Server usage; they refine reliability & UX.
-
-— “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson
 
 ## Documentation & maintenance scripts
 
@@ -494,4 +559,4 @@ To keep the code understandable and portable:
 
 This constraint can be revisited in later milestones if/when complexity warrants it.
 
-— “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson
+> Happy baking and organized browsing!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ReceptRegister
 
+![Build (Release Branches)](https://img.shields.io/github/actions/workflow/status/crswebb/ReceptRegister/release-deploy.yml?branch=release%2Fpreview-4&label=release%20build)
+![SDK](https://img.shields.io/badge/.NET-10.0_preview-blue)
+
 > “Let’s sift the chaos and find the perfect recipe to bake today.” — Bagare Bengtsson
 
 ReceptRegister is your personal, searchable index for pastry recipes from your book collection. Instead of flipping through sticky notes and indexes, you can find the right recipe in seconds and jump straight to the page.
@@ -7,38 +10,19 @@ ReceptRegister is your personal, searchable index for pastry recipes from your b
 ## Table of Contents
 1. [Overview](#overview)
 2. [Features](#features)
-	1. [What you can store](#what-you-can-store)
-	2. [What you can do](#what-you-can-do)
-	3. [How it feels](#how-it-feels-to-use)
-	4. [Everyday examples](#everyday-examples)
-	5. [Why it’s helpful](#why-its-helpful)
 3. [Quick Start](#quick-start)
-4. [Security & Access](#security--access)
-	1. [Password hashing & strength](#password-hashing--password-strength)
-	2. [Sessions & authentication endpoints](#sessions--authentication-endpoints)
-	3. [Password recovery & rotation](#password-recovery--rotation)
-	4. [Manual recovery (quick steps)](#manual-recovery-quick-steps)
-5. [Localization](#localization)
-	1. [Overrides (feature #137)](#localization-overrides-feature-137)
-	2. [Fixed culture groundwork](#localization-fixed-culture-groundwork)
-6. [UI / Frontend](#ui--frontend)
-	1. [Mobile friendly menu](#mobile-friendly-menu-feature-139)
-	2. [Theming & design tokens](#theming--design-tokens-ui-polish-milestone)
-7. [Data & Persistence](#data--persistence)
-	1. [Storage (alpha)](#data-storage-early-alpha)
-	2. [Database provider selection](#database-provider-selection-experimental)
-	3. [Data migration](#data-migration-sqlite-to-sql-server)
+4. [Security (Summary)](#security-summary) *(full: docs/security.md)*
+5. [Localization (Summary)](#localization-summary) *(full: docs/localization.md)*
+6. [UI / Frontend (Summary)](#ui--frontend-summary) *(full: docs/theming.md)*
+7. [Data & Persistence (Summary)](#data--persistence-summary) *(full: docs/data-migration.md)*
 8. [API](#api-milestone-4)
-	1. [Core endpoints](#core-endpoints)
-	2. [Query parameters](#query-parameters)
-	3. [Validation & errors](#validation--errors)
-	4. [Tried endpoint change](#tried-endpoint-change)
 9. [Running Locally](#running-locally-milestone-1-scaffolding)
 10. [Publishing](#publishing-self-contained-example)
 11. [Deployment](#deployment-neutral-note)
 12. [Roadmap & Future Ideas](#roadmap--future-ideas)
-13. [Documentation & Maintenance Scripts](#documentation--maintenance-scripts)
-14. [Dependency Policy](#dependency-policy-early-milestones)
+13. [Glossary](#glossary) *(docs/glossary.md)*
+14. [Documentation & Maintenance Scripts](#documentation--maintenance-scripts)
+15. [Dependency Policy](#dependency-policy-early-milestones)
 
 ---
 
@@ -47,6 +31,26 @@ ReceptRegister is your personal, searchable index for pastry recipes from your b
 Two apps make up ReceptRegister:
 - API (Minimal API): JSON endpoints & persistence.
 - Frontend (Razor Pages): HTML UI + also (optionally) hosts the API (single-process mode recommended).
+
+### Architecture Diagram
+
+```mermaid
+flowchart LR
+	user((User Browser)) --> FE[Frontend (Razor Pages)]
+	subgraph Single Process (default)
+		FE --> API[Minimal API Endpoints]
+	end
+	API --> DAL[(Repository Layer)]
+	DAL --> DIA[Database Dialect Abstraction]
+	DIA -->|SQLite| SQLITE[(SQLite File\nreceptregister.db)]
+	DIA -->|SQL Server| MSSQL[(SQL Server / Azure SQL)]
+	MIG[Optional One-shot Migration Runner]\n(SQLite -> SQL Server) --> MSSQL
+	%% Legend
+	classDef stor fill:#f9f9f9,stroke:#555,stroke-width:1px;
+	class SQLITE,MSSQL stor;
+```
+
+The diagram shows the default single-process mode where the frontend also exposes the Minimal API. A database dialect abstraction allows the same repositories to target either SQLite or SQL Server. A one‑shot migration helper can populate SQL Server from an existing SQLite library.
 
 ## Features
 
@@ -92,7 +96,31 @@ Then open the shown localhost URL, set the initial password, and start indexing 
 
 Need separate processes? See [Running Locally](#running-locally-milestone-1-scaffolding).
 
+### Contributing Quick Start
+Prerequisites: .NET SDK (see badge above for required major version), Git.
+
+Clone & run (single-process mode hosting UI + API):
+```powershell
+git clone https://github.com/crswebb/ReceptRegister.git
+cd ReceptRegister
+dotnet watch run --project ReceptRegister.Frontend
+```
+Create a branch:
+```powershell
+git checkout -b feature/your-change
+```
+Commit using a concise prefix (feat:, fix:, docs:, refactor:, chore:) and open a PR against `main` referencing an issue (policy enforced).
+
+Read: [CONTRIBUTING.md](CONTRIBUTING.md) for full guidelines (PR policy, testing, branch naming, commit style).
+
 ## Security & access
+<a id="security-summary"></a>
+**Summary:** Secure single-user access using PBKDF2 (SHA-256) hashed password with salt + optional pepper, in-memory session cookies (HttpOnly) with CSRF token for state-changing requests, rate-limited login, and manual recovery path by clearing the AuthConfig row. Full details (hash parameters, rotation, recovery, session endpoints) have been moved to `docs/security.md`.
+
+See: [Full Security Details](docs/security.md)
+<details>
+<summary><strong>Show full security details (hashing parameters, sessions, recovery…)</strong></summary>
+
 - The app is protected with a password.
 - On first visit, if no password has been set yet, you’ll be guided to create one.
 - After that, you’ll sign in before you can use the app.
@@ -115,39 +143,6 @@ Environment variables:
 If no pepper is configured a warning is logged at startup (safe for local dev). Changing the pepper after setting a password will invalidate verification (you would need to reset the password). Keep it stable and rotate only with a coordinated password reset.
 
 Password strength is evaluated server‑side (source of truth) with a 0–6 score (length >=8, length >=12, lowercase, uppercase, digit, symbol). A score of 3+ is required. The client progressively enhances the Set Password UI with a small meter and top suggestions; validation still occurs on the server.
-
-## Localization
-
-### Localization overrides (feature #137)
-Localization is configured via the `Localization` section in configuration files. You can now override the default and supported cultures using environment variables (takes precedence over config):
-
-| Variable | Example | Description |
-|----------|---------|-------------|
-| `RECEPT_DEFAULT_CULTURE` | `sv-SE` | Sets the default culture (thread + request). Falls back to `en-US` if invalid. |
-| `RECEPT_SUPPORTED_CULTURES` | `sv-SE,en-US` | Comma or semicolon separated list of supported culture codes. Invalid codes are skipped; if empty after filtering, default is used. |
-
-If `RECEPT_SUPPORTED_CULTURES` is omitted, the list comes from `Localization:SupportedCultures` or defaults to the single default culture.
-
-Example (PowerShell):
-```powershell
-$env:RECEPT_DEFAULT_CULTURE = 'sv-SE'
-$env:RECEPT_SUPPORTED_CULTURES = 'sv-SE,en-US'
-dotnet run --project ReceptRegister.Frontend
-```
-The application will start with `sv-SE` active and both `sv-SE` / `en-US` registered.
-
-## UI / Frontend
-
-### Mobile friendly menu (feature #139)
-On small screens (<=700px width) the primary navigation collapses behind a toggle button labeled "Menu" (localized). Tapping the button expands the list in a vertical column; tapping again closes it. The button's accessible state is conveyed via `aria-expanded` and its label changes to "Close menu" when open. On larger viewports the menu is always visible and the toggle is hidden.
-
-No configuration is required. Internationalization keys added:
-| Key | English | Swedish |
-|-----|---------|---------|
-| `Nav.Menu` | Menu | Meny |
-| `Nav.CloseMenu` | Close menu | Stäng meny |
-
-Progressive enhancement: if JavaScript fails to load, the list remains visible (graceful degradation) because the markup renders the `<nav>` normally and the toggle button (if shown) does not hide content without script.
 
 ### Sessions & authentication endpoints
 After setting a password via `POST /auth/set-password`, obtain a session with `POST /auth/login`.
@@ -230,6 +225,61 @@ Alternative: you may delete the entire `receptregister.db` file instead (after b
 
 Keep the backup until you confirm the new password works and data (if preserved) is intact.
 
+</details>
+
+## Localization
+<a id="localization-summary"></a>
+**Summary:** Localization groundwork lets you set a default culture and supported cultures via configuration or environment variables (`RECEPT_DEFAULT_CULTURE`, `RECEPT_SUPPORTED_CULTURES`). UI strings live in resource files with planned future user-selectable switching. Detailed override examples, resource usage, and troubleshooting moved to `docs/localization.md`.
+
+See: [Full Localization Guide](docs/localization.md)
+<details>
+<summary><strong>Show localization override examples & resource workflow…</strong></summary>
+
+### Localization overrides (feature #137)
+Localization is configured via the `Localization` section in configuration files. You can now override the default and supported cultures using environment variables (takes precedence over config):
+
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `RECEPT_DEFAULT_CULTURE` | `sv-SE` | Sets the default culture (thread + request). Falls back to `en-US` if invalid. |
+| `RECEPT_SUPPORTED_CULTURES` | `sv-SE,en-US` | Comma or semicolon separated list of supported culture codes. Invalid codes are skipped; if empty after filtering, default is used. |
+
+If `RECEPT_SUPPORTED_CULTURES` is omitted, the list comes from `Localization:SupportedCultures` or defaults to the single default culture.
+
+Example (PowerShell):
+```powershell
+$env:RECEPT_DEFAULT_CULTURE = 'sv-SE'
+$env:RECEPT_SUPPORTED_CULTURES = 'sv-SE,en-US'
+dotnet run --project ReceptRegister.Frontend
+```
+The application will start with `sv-SE` active and both `sv-SE` / `en-US` registered.
+</details>
+
+## UI / Frontend
+<a id="ui--frontend-summary"></a>
+**Summary:** Responsive Razor Pages UI with progressive enhancement: mobile navigation toggle, theme (light/dark) via CSS design tokens, accessible focus/contrast, recipe layout options, and client helpers for auth/session + password strength meter. Deep theming and token catalog moved to `docs/theming.md`.
+
+See: [Theming & Design Tokens](docs/theming.md)
+<details>
+<summary><strong>Show UI details (mobile menu, sessions, recovery steps)…</strong></summary>
+
+### Mobile friendly menu (feature #139)
+On small screens (<=700px width) the primary navigation collapses behind a toggle button labeled "Menu" (localized). Tapping the button expands the list in a vertical column; tapping again closes it. The button's accessible state is conveyed via `aria-expanded` and its label changes to "Close menu" when open. On larger viewports the menu is always visible and the toggle is hidden.
+
+No configuration is required. Internationalization keys added:
+| Key | English | Swedish |
+|-----|---------|---------|
+| `Nav.Menu` | Menu | Meny |
+| `Nav.CloseMenu` | Close menu | Stäng meny |
+
+Progressive enhancement: if JavaScript fails to load, the list remains visible (graceful degradation) because the markup renders the `<nav>` normally and the toggle button (if shown) does not hide content without script.
+
+### (Legacy duplicates) Sessions, recovery and manual recovery
+These details are retained for convenience but are also covered under Security details above.
+
+<!-- (Content removed here to avoid duplication; see security details block) -->
+
+</details>
+
 ## Roadmap & Future Ideas
 
 ### Future ideas
@@ -240,6 +290,12 @@ Keep the backup until you confirm the new password works and data (if preserved)
 - Print or share a shortlist when planning a baking day.
 
 ## Data & Persistence
+<a id="data--persistence-summary"></a>
+**Summary:** Pluggable storage via a provider abstraction: default SQLite file or SQL Server backend selected by configuration. Repositories use a database dialect for SQL differences. A one-shot migrator can seed SQL Server from an existing SQLite file (idempotent taxonomy upsert + natural key dedupe). Full migration usage & provider notes moved to `docs/data-migration.md`.
+
+See: [Data Migration & Provider Details](docs/data-migration.md)
+<details>
+<summary><strong>Show full data provider & migration details…</strong></summary>
 
 ### Data storage (early alpha)
 The API persists data to a local SQLite file at `App_Data/receptregister.db` (created on first run) by default. (NEW: An experimental SQL Server provider is now selectable – see next section.) Schema is simple:
@@ -317,6 +373,8 @@ After migration:
 - Start the combined Frontend (or API) normally pointing at SQL Server.
 - Visit the site; you will be in setup mode (no password) unless you manually migrated AuthConfig which is intentionally not handled.
 - Set a new password and verify recipes appear.
+
+</details>
 
 ## Deployment (neutral note)
 
@@ -560,3 +618,7 @@ To keep the code understandable and portable:
 This constraint can be revisited in later milestones if/when complexity warrants it.
 
 > Happy baking and organized browsing!
+
+## Glossary
+
+See [docs/glossary.md](docs/glossary.md) for definitions of recurring terms (Dialect, Migration Runner, Taxonomy, Pepper, etc.).

--- a/docs/data-migration.md
+++ b/docs/data-migration.md
@@ -1,0 +1,79 @@
+# Data Migration & Database Providers
+
+This document expands on database provider selection and the SQLite → SQL Server migration helper.
+
+## Contents
+- [Providers Overview](#providers-overview)
+- [Configuration](#configuration)
+- [Schema Initialization](#schema-initialization)
+- [Dialect Abstraction](#dialect-abstraction)
+- [Migration Helper Usage](#migration-helper-usage)
+- [Safety & Idempotency](#safety--idempotency)
+- [Limitations & Roadmap](#limitations--roadmap)
+
+## Providers Overview
+Supported:
+- SQLite (file-based, default, minimal setup)
+- SQL Server / Azure SQL (experimental, expanding coverage)
+
+Choose via config key `Database:Provider` (`SQLite` or `SqlServer`).
+
+## Configuration
+`appsettings.json` (or environment variables overriding):
+```json
+{
+  "Database": {
+    "Provider": "SQLite",
+    "ConnectionString": ""  
+  }
+}
+```
+When `Provider=SqlServer` a non-empty `ConnectionString` is required; the application will fail fast otherwise.
+
+## Schema Initialization
+`ISchemaInitializer` implementation selected at runtime:
+- `SqliteSchemaInitializer` – create-if-not-exists DDL
+- `SqlServerSchemaInitializer` – guarded DDL (`IF NOT EXISTS`)
+
+Executed early during startup for both API & Frontend hosts.
+
+## Dialect Abstraction
+`IDatabaseDialect` provides SQL differences (identity retrieval, upserts, paging) so repositories remain mostly neutral. Some SQL Server edge optimizations may be pending.
+
+## Migration Helper Usage
+One-shot helper to migrate existing SQLite content to SQL Server.
+
+Steps:
+1. Configure target: `Database:Provider=SqlServer` + valid connection string.
+2. Run API with extra argument:
+   ```powershell
+   dotnet run --project ReceptRegister.Api -- --migrate-sqlite="C:\\path\\receptregister.db"
+   ```
+3. Process:
+   - Ensures target schema exists
+   - Reads taxonomy & recipes from source file
+   - Upserts taxonomy (skips existing names)
+   - Inserts recipes (skips natural key duplicates: Name+Book+Page)
+   - Recreates many-to-many links
+4. Exits (does not start web server) on success.
+
+## Safety & Idempotency
+- Re-runnable: duplicates skipped
+- Does not delete or truncate target tables
+- Source file opened read-only
+
+## Limitations & Roadmap
+Current limitations:
+- No reverse (SQL Server → SQLite)
+- No incremental diff; full copy each run
+- Password (`AuthConfig`) intentionally not migrated
+- Loads all recipes into memory (acceptable for small libs)
+- Lacks automated integration test (planned)
+
+Planned / referenced issues:
+- #118 integration test for `DataMigrationRunner`
+- #119 optional `AuthConfig` migration
+- #120 dry-run / summary mode
+
+---
+← Previous: [Security](./security.md) | Next: [Theming](./theming.md) →

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,17 @@
+# Glossary
+
+Key terms and their concise definitions.
+
+| Term | Definition |
+|------|------------|
+| Taxonomy | Collective term for Categories and Keywords; both are many-to-many linked to recipes. |
+| Tried | Boolean flag indicating whether the recipe has been baked/tested. |
+| Dialect | Runtime abstraction (`IDatabaseDialect`) supplying provider-specific SQL fragments (identity retrieval, upserts, paging). |
+| Schema Initializer | Implementation of `ISchemaInitializer` that provisions database schema if missing. |
+| Migration Runner | One-shot process that copies data from a SQLite file into a SQL Server database. |
+| Pepper | Secret string appended to a password prior to PBKDF2 hashing (defense in depth). |
+| Iterations | PBKDF2 work factor controlling hash computation time for brute force resistance. |
+| AuthConfig | Table storing the single password hash + salt + iteration metadata for admin access. |
+
+---
+← Previous: [Localization](./localization.md) | Next: (none)

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -1,0 +1,79 @@
+# Localization
+
+Centralized details on culture configuration, resource files, and translation workflow.
+
+## Contents
+- [Runtime Overrides](#runtime-overrides)
+- [Fixed Culture Configuration](#fixed-culture-configuration)
+- [Resource Files](#resource-files)
+- [Adding UI Strings](#adding-ui-strings)
+- [Dynamic Strings](#dynamic-strings)
+- [Translation Workflow](#translation-workflow)
+- [Troubleshooting](#troubleshooting)
+- [Adding Another Language](#adding-another-language)
+
+## Runtime Overrides
+Environment variables supersede config section values:
+| Variable | Example | Description |
+|----------|---------|-------------|
+| `RECEPT_DEFAULT_CULTURE` | `sv-SE` | Default thread + request culture (falls back to `en-US` if invalid) |
+| `RECEPT_SUPPORTED_CULTURES` | `sv-SE,en-US` | Comma/semicolon list; invalid codes skipped; if empty -> default only |
+
+Example (PowerShell):
+```powershell
+$env:RECEPT_DEFAULT_CULTURE = 'sv-SE'
+$env:RECEPT_SUPPORTED_CULTURES = 'sv-SE,en-US'
+dotnet run --project ReceptRegister.Frontend
+```
+
+## Fixed Culture Configuration
+Config section (per project):
+```jsonc
+"Localization": {
+  "DefaultCulture": "en-US",
+  "SupportedCultures": [ "en-US" ]
+}
+```
+Only fixed provider registered today (no Accept-Language / cookie negotiation yet).
+
+## Resource Files
+Located in `ReceptRegister.Frontend/Resources/`:
+- `SharedResources.resx` (default English)
+- `SharedResources.sv.resx` (Swedish placeholders)
+
+Key prefixes: Nav.*, Button.*, Table.*, Page.*, Form.*, A11y.*
+
+## Adding UI Strings
+1. Add key + value to default `.resx`.
+2. Add same key to every other culture file (even if untranslated).
+3. Inject and use: `@inject IStringLocalizer<SharedResources> L` then `@L["Button.Search"]`.
+
+## Dynamic Strings
+Format placeholders (`{0}`, `{1}`) enable localized grammar, e.g.:
+```csharp
+@string.Format(L["A11y.Recipes.ResultsCount"], total, pluralSuffix, page, totalPages)
+```
+Preserve placeholders exactly.
+
+## Translation Workflow
+1. Extract keys (done #99)
+2. Provide Swedish translations (#100)
+3. Add optional user language switch (#97 future)
+
+## Troubleshooting
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Still English after change | App not restarted | Restart app
+| Literal `{0}` output | Missing string.Format | Wrap resource in formatting
+| Partial fallback to English | Key missing in culture file | Add missing key
+
+## Adding Another Language
+1. Copy `SharedResources.resx` to `SharedResources.<culture>.resx`
+2. Translate values (keep placeholders)
+3. Add culture code to `SupportedCultures`
+4. Restart application
+
+Roadmap: eventual user-selectable language + persisted preference.
+
+---
+← Previous: [Theming](./theming.md) | Next: [Glossary](./glossary.md) →

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,80 @@
+# Security
+
+This document consolidates security-related guidance extracted from the README.
+
+## Contents
+- [Password Hashing](#password-hashing)
+- [Session Management](#session-management)
+- [Password Recovery & Rotation](#password-recovery--rotation)
+- [Manual Recovery (SQL Quick Steps)](#manual-recovery-sql-quick-steps)
+- [Disaster Recovery Checklist](#disaster-recovery-checklist)
+- [Environment Variables](#environment-variables)
+- [Threat Reminders](#threat-reminders)
+
+## Password Hashing
+PBKDF2 (SHA-256) with per-user 32-byte random salt, configurable iteration count (env `RECEPT_PBKDF2_ITERATIONS`, default 150,000), optional global pepper `RECEPT_PEPPER` concatenated before hashing.
+
+Strength meter (server authoritative) scores 0–6 across: length >=8, length >=12, lowercase, uppercase, digit, symbol. Minimum accepted score = 3.
+
+Pepper guidance:
+- DO set a long random pepper in production
+- DO keep it outside source control (secret store / env)
+- DON’T rotate casually (rotation invalidates existing hashes)
+
+## Session Management
+Endpoints:
+- `POST /auth/set-password` – one time setup
+- `POST /auth/login` – returns `{ expiresAt, csrf }` + creates `rr_session` HttpOnly cookie
+- `POST /auth/change-password` – requires current password + CSRF
+- `POST /auth/refresh` – prolong current session
+- `GET /auth/status` – status shape: `{ hasPassword, authenticated, expiresAt?, csrf? }`
+
+Include `X-CSRF-TOKEN` for any state-changing method (POST/PUT/PATCH/DELETE). Read-only GETs do not need it.
+
+Rate limiting (defaults): 5 failed logins / 5 minute sliding window per IP (configurable with `RECEPT_LOGIN_MAX_ATTEMPTS` / `RECEPT_LOGIN_WINDOW_SECONDS`).
+
+Sessions are in-memory (single process). Restart invalidates them—acceptable for personal scope.
+
+## Password Recovery & Rotation
+Lost password -> force setup mode:
+1. Stop process.
+2. Delete row from `AuthConfig` table (see manual recovery below).
+3. Start app, set a new password.
+
+Pepper rotation procedure:
+1. Maintenance window (read-only).
+2. Delete `AuthConfig` row.
+3. Set new `RECEPT_PEPPER` env.
+4. Start app, set password anew.
+
+Iteration increases: safe anytime; hashes rehashed lazily on successful login.
+
+## Manual Recovery (SQL Quick Steps)
+```sql
+DELETE FROM AuthConfig WHERE Id=1;
+VACUUM; -- optional
+```
+Then restart the app and set a new password.
+
+## Disaster Recovery Checklist
+- Backup: copy `App_Data/receptregister.db` while stopped
+- Restore: replace file, ensure file permissions
+- Integrity check: `SELECT COUNT(*) FROM Recipes;`
+
+## Environment Variables
+| Variable | Purpose | Recommendation |
+|----------|---------|---------------|
+| `RECEPT_PBKDF2_ITERATIONS` | Hash iteration count | >=150k, raise gradually |
+| `RECEPT_PEPPER` | Global pepper secret | Long random, prod only |
+| `RECEPT_SESSION_MINUTES` | Session lifetime | 120 default |
+| `RECEPT_LOGIN_MAX_ATTEMPTS` | Max failed logins | 5 default |
+| `RECEPT_LOGIN_WINDOW_SECONDS` | Rate limit window | 300 |
+
+## Threat Reminders
+- Keep pepper secret; never log it.
+- Monitor iteration performance (< ~250ms target per hash).
+- Limit brute force via rate limiting.
+- Use HTTPS in production (reverse proxy or Kestrel with cert) so session cookie confidentiality is preserved.
+
+---
+← Previous: (none) | Next: [Data Migration](./data-migration.md) →

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,43 @@
+# Theming & Design Tokens
+
+This document details the lightweight design token system and UI conventions.
+
+## Contents
+- [Token Categories](#token-categories)
+- [Dark Mode](#dark-mode)
+- [Components Using Tokens](#components-using-tokens)
+- [Adding Tokens](#adding-tokens)
+- [Accessibility](#accessibility)
+
+## Token Categories
+Defined in `wwwroot/css/variables.css`:
+- Colors: `--color-*` (text, background, surface, primary, danger, success, warning, link, focus, shadow palette)
+- Spacing: `--spacing-0..8` (2px scale)
+- Typography: `--fs-*`, `--fw-*`, line heights
+- Radii: `--radius-*`, including `--radius-pill`
+- Elevation: `--elevation-*` shadow presets
+- Motion: generic transition variables
+- Z-indices: layer ordering tokens
+
+## Dark Mode
+Automatic via `prefers-color-scheme: dark`; user override persisted in `localStorage` key `rr_theme` and applied by toggling `data-theme="dark|light"` on `<html>`.
+
+## Components Using Tokens
+- Buttons (variants: primary, outline, subtle, danger, secondary; sizes sm, default, lg)
+- Forms (consistent spacing, focus ring via token)
+- Tables (responsive stacking, accessible caption)
+- Pagination
+- Recipe list (table vs card layout preference `rr_recipe_layout`)
+
+## Adding Tokens
+1. Add the new variable in `variables.css` with a meaningful semantic name.
+2. Reference it in component styles; avoid raw hex or magic numbers.
+3. Verify contrast if it affects text or interactive states.
+
+## Accessibility
+- Contrast meets WCAG AA (text 4.5:1 normal, 3:1 large)
+- Focus indicators: 2px outline using `--color-focus-outline`
+- Avoid conveying meaning solely with color; pair with icon/text where possible.
+
+---
+← Previous: [Data Migration](./data-migration.md) | Next: [Localization](./localization.md) →

--- a/tools/check-readme-lines.ps1
+++ b/tools/check-readme-lines.ps1
@@ -1,0 +1,23 @@
+param(
+    [int]$MaxLines = ${env:README_MAX_LINES} -as [int] -or 350,
+    [switch]$FailAbove = [bool](${env:README_FAIL_ABOVE} -as [int])
+)
+
+$readmePath = Join-Path $PSScriptRoot '..' 'README.md'
+if (-not (Test-Path $readmePath)) {
+    Write-Host "README.md not found at $readmePath" -ForegroundColor Red
+    exit 2
+}
+$count = (Get-Content $readmePath | Measure-Object -Line).Lines
+if ($count -le $MaxLines) {
+    Write-Host "README line count: $count (<= $MaxLines) : OK" -ForegroundColor Green
+    exit 0
+}
+$msg = "README line count $count exceeds limit $MaxLines. Consider extracting content into docs/."
+if ($FailAbove) {
+    Write-Host $msg -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host $msg -ForegroundColor Yellow
+    exit 0
+}


### PR DESCRIPTION
Closes #141 
Closes #146 
Closes #147 
Closes #149 
Closes #150 
Closes #151 
Closes #152 
Closes #153 
Closes #154 

Summary:
Restructures and slims the root README while extracting long-form content to topic docs.

Key Changes:
- Added build + SDK badges.
- Inserted Architecture diagram (Mermaid) for system overview (#149).
- Added concise summary sections (Security, Localization, UI, Data) with anchors (#146).
- Moved detailed content into new docs folder: security, localization, theming, data-migration, glossary (#146, #151).
- Added contributing quick start section (#150).
- Added Prev/Next nav footers across docs pages (#152).
- Collapsed verbose legacy detail into <details> blocks (#148/#153).
- Added README size advisory check in PR workflow and standalone PowerShell script (#154).

New Files:
- docs/security.md
- docs/localization.md
- docs/theming.md
- docs/data-migration.md
- docs/glossary.md
- tools/check-readme-lines.ps1

CI / Tooling:
- Updated pr-policy workflow with advisory README line count step.

Branch Naming Compliance:
- Renamed branch to docs/141-readme-slim-and-extract to match required pattern.

Notes:
- No runtime code changes; documentation + workflow only.
- Follow-up possible: enforce hard limit via env if needed.

Please review for merge into main. Thanks!