### PR TITLE
docs: fix mermaid architecture diagram syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ Two apps make up ReceptRegister:
 ```mermaid
 flowchart LR
 	user((User Browser)) --> FE[Frontend (Razor Pages)]
-	subgraph Single Process (default)
+	subgraph SingleProcess [Single Process (default)]
 		FE --> API[Minimal API Endpoints]
 	end
 	API --> DAL[(Repository Layer)]
 	DAL --> DIA[Database Dialect Abstraction]
 	DIA -->|SQLite| SQLITE[(SQLite File\nreceptregister.db)]
 	DIA -->|SQL Server| MSSQL[(SQL Server / Azure SQL)]
-	MIG[Optional One-shot Migration Runner]\n(SQLite -> SQL Server) --> MSSQL
+	MIG["Optional One-shot Migration Runner\n(SQLite -> SQL Server)"] --> MSSQL
 	%% Legend
 	classDef stor fill:#f9f9f9,stroke:#555,stroke-width:1px;
 	class SQLITE,MSSQL stor;


### PR DESCRIPTION
Closes #141

Small follow-up to correct Mermaid syntax so the architecture diagram renders on GitHub.

Change:
- Adjust subgraph declaration to use an ID without spaces and separate label.
- Wrap migration runner node label in quotes with newline inside bracket for valid parsing.

No other content changes.

Thanks!