### PR TITLE
docs: simplified mermaid diagram to resolve GitHub render error

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,15 @@ Two apps make up ReceptRegister:
 
 ```mermaid
 flowchart LR
-	user((User Browser)) --> FE[Frontend (Razor Pages)]
-	subgraph SingleProcess [Single Process (default)]
-		FE --> API[Minimal API Endpoints]
-	end
-	API --> DAL[(Repository Layer)]
-	DAL --> DIA[Database Dialect Abstraction]
-	DIA -->|SQLite| SQLITE[(SQLite File\nreceptregister.db)]
-	DIA -->|SQL Server| MSSQL[(SQL Server / Azure SQL)]
-	MIG["Optional One-shot Migration Runner\n(SQLite -> SQL Server)"] --> MSSQL
-	%% Legend
-	classDef stor fill:#f9f9f9,stroke:#555,stroke-width:1px;
-	class SQLITE,MSSQL stor;
+    user((User Browser)) --> FE[Frontend (Razor Pages)]
+    FE --> API[Minimal API Endpoints]
+    API --> DAL[(Repository Layer)]
+    DAL --> DIA[Database Dialect Abstraction]
+    DIA --> SQLITE[(SQLite File\nreceptregister.db)]
+    DIA --> MSSQL[(SQL Server / Azure SQL)]
+    MIG["Migration Runner\n(SQLite -> SQL Server)"] --> MSSQL
+    classDef stor fill:#f9f9f9,stroke:#555,stroke-width:1px;
+    class SQLITE,MSSQL stor;
 ```
 
 The diagram shows the default single-process mode where the frontend also exposes the Minimal API. A database dialect abstraction allows the same repositories to target either SQLite or SQL Server. A one‑shot migration helper can populate SQL Server from an existing SQLite library.


### PR DESCRIPTION
Closes #141

Follow-up to PR #156: the initial syntax adjustment still produced a GitHub Mermaid parse error. This commit simplifies the diagram (removes subgraph & edge labels) so it renders reliably.

Changes:
- Remove subgraph wrapper and edge labels.
- Shorten migration runner node label.
- Keep storage node styling.

Once merged we can iteratively reintroduce elements if desired, testing each step.

No other content changes.