### PR TITLE
feat(infra): automate App Service settings & robust culture parsing

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -110,6 +110,18 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Configure App Service Settings (Issue #166)
+        uses: azure/appservice-settings@v1
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          app-settings-json: |
+            [
+              { "name": "RECEPT_DEFAULT_CULTURE", "value": "${{ env.RECEPT_DEFAULT_CULTURE }}", "slotSetting": false },
+              { "name": "RECEPT_SUPPORTED_CULTURES", "value": "${{ env.RECEPT_SUPPORTED_CULTURES }}", "slotSetting": false },
+              { "name": "RECEPT_DB_PROVIDER", "value": "SqlServer", "slotSetting": false },
+              { "name": "RECEPT_DB_CONNECTIONSTRING", "value": "${{ secrets.RECEPT_DB_CONNECTIONSTRING }}", "slotSetting": true }
+            ]
+
       # - name: Configure App Settings
       #   if: ${{ github.event_name == 'push' }}
       #   run: |

--- a/ReceptRegister.Api/Localization/LocalizationExtensions.cs
+++ b/ReceptRegister.Api/Localization/LocalizationExtensions.cs
@@ -31,7 +31,11 @@ public static class LocalizationExtensions
         string[] supported;
         if (!string.IsNullOrWhiteSpace(envSupportedRaw))
         {
-            var split = envSupportedRaw.Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            var split = envSupportedRaw
+                .Split(new[] { ',', ';' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(s => TrimWrappingQuotes(s))
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToArray();
             supported = split.Length > 0 ? split : new[] { defaultCultureName };
         }
         else
@@ -100,5 +104,17 @@ public static class LocalizationExtensions
         public FixedOnlyRequestCultureProvider(CultureInfo culture) => _culture = new RequestCulture(culture);
         public Task<ProviderCultureResult?> DetermineProviderCultureResult(HttpContext httpContext)
             => Task.FromResult<ProviderCultureResult?>(new ProviderCultureResult(_culture.Culture.Name, _culture.UICulture.Name));
+    }
+
+    private static string TrimWrappingQuotes(string input)
+    {
+        if (input.Length >= 2)
+        {
+            if ((input[0] == '"' && input[^1] == '"') || (input[0] == '\'' && input[^1] == '\''))
+            {
+                return input.Substring(1, input.Length - 2).Trim();
+            }
+        }
+        return input;
     }
 }

--- a/ReceptRegister.Tests/LocalizationEnvOverrideTests.cs
+++ b/ReceptRegister.Tests/LocalizationEnvOverrideTests.cs
@@ -59,4 +59,29 @@ public class LocalizationEnvOverrideTests
             Environment.SetEnvironmentVariable("RECEPT_DEFAULT_CULTURE", oldDef);
         }
     }
+
+    [Fact]
+    public async Task QuotedSupportedCultures_Are_Trimmed()
+    {
+        var oldDef = Environment.GetEnvironmentVariable("RECEPT_DEFAULT_CULTURE");
+        var oldSupp = Environment.GetEnvironmentVariable("RECEPT_SUPPORTED_CULTURES");
+        try
+        {
+            Environment.SetEnvironmentVariable("RECEPT_DEFAULT_CULTURE", "sv-SE");
+            Environment.SetEnvironmentVariable("RECEPT_SUPPORTED_CULTURES", "\"sv-SE\",\"en-US\"");
+            var builder = WebApplication.CreateBuilder(Array.Empty<string>());
+            builder.Services.AddLocalization();
+            builder.Services.AddConfiguredLocalization(builder.Configuration);
+            var app = builder.Build();
+            var opts = app.Services.GetRequiredService<Microsoft.Extensions.Options.IOptions<RequestLocalizationOptions>>().Value;
+            var names = opts.SupportedCultures.Select(c => c.Name).ToArray();
+            Assert.Contains("sv-SE", names);
+            Assert.Contains("en-US", names);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("RECEPT_DEFAULT_CULTURE", oldDef);
+            Environment.SetEnvironmentVariable("RECEPT_SUPPORTED_CULTURES", oldSupp);
+        }
+    }
 }


### PR DESCRIPTION
Closes #166

Implements Option C described in issue:
- Adds `azure/appservice-settings@v1` step to `release-deploy.yml` so RECEPT_* env vars are persisted as App Service settings on each deploy.
- Stores DB connection string via secret `RECEPT_DB_CONNECTIONSTRING` (slotSetting true) and sets provider to SqlServer.
- Extends `LocalizationExtensions` to trim wrapping single/double quotes per culture token, tolerating accidental quoted lists like "sv-SE","en-US".
- Adds test `QuotedSupportedCultures_Are_Trimmed`.

All tests pass locally (35/35).