### PR TITLE
feat(infra): robust app settings JSON + pepper deployment

### DIFF
--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -116,11 +116,11 @@ jobs:
           app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
           app-settings-json: |
             [
-              { "name": "RECEPT_DEFAULT_CULTURE", "value": "${{ env.RECEPT_DEFAULT_CULTURE }}", "slotSetting": false },
-              { "name": "RECEPT_SUPPORTED_CULTURES", "value": "${{ env.RECEPT_SUPPORTED_CULTURES }}", "slotSetting": false },
+              { "name": "RECEPT_DEFAULT_CULTURE", "value": ${{ toJson(env.RECEPT_DEFAULT_CULTURE) }}, "slotSetting": false },
+              { "name": "RECEPT_SUPPORTED_CULTURES", "value": ${{ toJson(env.RECEPT_SUPPORTED_CULTURES) }}, "slotSetting": false },
               { "name": "RECEPT_DB_PROVIDER", "value": "SqlServer", "slotSetting": false },
-              { "name": "RECEPT_DB_CONNECTIONSTRING", "value": "${{ secrets.RECEPT_DB_CONNECTIONSTRING }}", "slotSetting": true },
-              { "name": "RECEPT_PEPPER", "value": "${{ secrets.RECEPT_PEPPER_VALUE }}", "slotSetting": true }
+              { "name": "RECEPT_DB_CONNECTIONSTRING", "value": ${{ toJson(secrets.RECEPT_DB_CONNECTIONSTRING) }}, "slotSetting": true },
+              { "name": "RECEPT_PEPPER", "value": ${{ toJson(secrets.RECEPT_PEPPER_VALUE) }}, "slotSetting": true }
             ]
 
       # - name: Configure App Settings

--- a/.github/workflows/release-deploy.yml
+++ b/.github/workflows/release-deploy.yml
@@ -119,7 +119,8 @@ jobs:
               { "name": "RECEPT_DEFAULT_CULTURE", "value": "${{ env.RECEPT_DEFAULT_CULTURE }}", "slotSetting": false },
               { "name": "RECEPT_SUPPORTED_CULTURES", "value": "${{ env.RECEPT_SUPPORTED_CULTURES }}", "slotSetting": false },
               { "name": "RECEPT_DB_PROVIDER", "value": "SqlServer", "slotSetting": false },
-              { "name": "RECEPT_DB_CONNECTIONSTRING", "value": "${{ secrets.RECEPT_DB_CONNECTIONSTRING }}", "slotSetting": true }
+              { "name": "RECEPT_DB_CONNECTIONSTRING", "value": "${{ secrets.RECEPT_DB_CONNECTIONSTRING }}", "slotSetting": true },
+              { "name": "RECEPT_PEPPER", "value": "${{ secrets.RECEPT_PEPPER_VALUE }}", "slotSetting": true }
             ]
 
       # - name: Configure App Settings


### PR DESCRIPTION
Closes #169

Adds RECEPT_PEPPER app setting + hardens JSON for all settings using toJson() to avoid parsing errors.
Also covers prior Issue #166 robustness for culture lists.
