### PR TITLE
Cleanup: Remove merge markers and duplicate usings (Program.cs & HealthExtensions)

### DIFF
--- a/ReceptRegister.Api/HealthExtensions.cs
+++ b/ReceptRegister.Api/HealthExtensions.cs
@@ -1,8 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-using ReceptRegister.Api.Data;
-using System.Data;
+// using directives cleaned (removed duplicates)
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using ReceptRegister.Api.Data;
 using System.Data;

--- a/ReceptRegister.Api/HealthExtensions.cs
+++ b/ReceptRegister.Api/HealthExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
-// using directives cleaned (removed duplicates)
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using ReceptRegister.Api.Data;
 using System.Data;

--- a/ReceptRegister.Frontend/Program.cs
+++ b/ReceptRegister.Frontend/Program.cs
@@ -30,23 +30,7 @@ if (!app.Environment.IsDevelopment())
 
 app.UseRouting();
 
-<<<<<<< HEAD
-// Ensure DB schema exists for shared API endpoints (recipes, auth, taxonomy) using provider abstraction
-// Capture failure so health endpoint can surface it instead of perpetual platform 503.
-var startupStatus = app.Services.GetRequiredService<ReceptRegister.Api.StartupStatus>();
-try
-{
-    await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
-    startupStatus.ReportSuccess();
-}
-catch (Exception ex)
-{
-    app.Logger.LogError(ex, "Schema initialization failed; application will continue so /api/health can report the failure.");
-    startupStatus.ReportFailure(ex);
-}
-=======
-// Schema initialization + migrations now handled by SchemaStartupHostedService (background) so app can report 'starting'.
->>>>>>> origin/test-merge-preview-migrations-refactor
+// Schema initialization + migrations handled by SchemaStartupHostedService (background) so health can show 'starting'.
 // Auth session (cookie + csrf) before endpoints
 app.UseAuthSession();
 
@@ -61,7 +45,3 @@ app.MapRazorPages()
 app.MapApiEndpoints();
 
 app.MapAppHealth();
-
-app.UseRouting();
-
-// Schema initialization + migrations handled by SchemaStartupHostedService (background) so health can show 'starting'.


### PR DESCRIPTION
Purpose
Removes leftover merge conflict markers and duplicate using directives introduced by earlier merged refactor PR.

Changes
- Program.cs: removed conflict markers, old inline schema initialization block, duplicate trailing UseRouting.
- HealthExtensions.cs: removed duplicate using directives (ReceptRegister.Api.Data, System.Data) to eliminate warnings.

No functional code changes; only cleanup for build hygiene and readability.

Testing
- Solution builds locally with zero warnings related to these files.

Risk
None (purely cosmetic / structural cleanup).

Please merge to keep main clean and warning-free.
