### PR TITLE
[preview-5] Backport: health detailed startup error exposure

### DIFF
--- a/.github/workflows/pr-policy.yml
+++ b/.github/workflows/pr-policy.yml
@@ -57,7 +57,7 @@ jobs:
                 core.setFailed(`Branch '${branch}' does not match naming pattern: type/(scope-)?<issueNumber>-<short-slug>`);
               }
 
-              const closesRe = /(Closes|Fixes) #\\d+/i;
+              const closesRe = /(Closes|Fixes) #\d+/i;
               if (!closesRe.test(body)) {
                 core.setFailed('PR body must include issue linkage, e.g., "Closes #123"');
               }

--- a/ReceptRegister.Api/Data/SchemaMigrations/SchemaMigrator.cs
+++ b/ReceptRegister.Api/Data/SchemaMigrations/SchemaMigrator.cs
@@ -34,7 +34,11 @@ public sealed class SchemaMigrator : ISchemaMigrator
             int applied = 0, skipped = 0;
             foreach (var m in ordered)
             {
-                if (appliedIds.Contains(m.Id)) { skipped++; continue; }
+                if (appliedIds.Contains(m.Id))
+                {
+                    skipped++;
+                    continue;
+                }
                 _logger.LogInformation("Applying migration {Id} {Name}...", m.Id, m.Name);
                 await using var tx = await conn.BeginTransactionAsync(ct);
                 await using (var cmd = conn.CreateCommand())

--- a/ReceptRegister.Api/Data/SqlServerConnectionFactory.cs
+++ b/ReceptRegister.Api/Data/SqlServerConnectionFactory.cs
@@ -32,9 +32,17 @@ public class SqlServerConnectionFactory : IDbConnectionFactory
         var conn = new SqlConnection(_connectionString);
         if (_useEntra && _credential is not null)
         {
-            // Acquire token lazily on open (SqlClient supports AccessToken assignment prior to Open)
-            var token = _credential.GetToken(new TokenRequestContext(new[] { "https://database.windows.net/.default" }), System.Threading.CancellationToken.None);
-            conn.AccessToken = token.Token;
+            // Acquire token with a bounded timeout to avoid indefinite hangs on metadata endpoint issues.
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            try
+            {
+                var token = _credential.GetToken(new TokenRequestContext(new[] { "https://database.windows.net/.default" }), cts.Token);
+                conn.AccessToken = token.Token;
+            }
+            catch (OperationCanceledException)
+            {
+                throw new TimeoutException("Timed out acquiring Entra ID access token for SQL Server within 15s.");
+            }
         }
         return conn;
     }

--- a/ReceptRegister.Api/HealthExtensions.cs
+++ b/ReceptRegister.Api/HealthExtensions.cs
@@ -69,7 +69,6 @@ public static class HealthExtensions
 			return Results.Json(new { status = "ok", app = "api", initialized = true });
 		});
 
-<<<<<<< HEAD
 		// Plain text convenience endpoint for quick copy/paste of startup error (respects same exposure gating as /api/health?details).
 		endpoints.MapGet("/api/startup-error", (StartupStatus status, IConfiguration config, IWebHostEnvironment env) =>
 		{

--- a/ReceptRegister.Api/HealthExtensions.cs
+++ b/ReceptRegister.Api/HealthExtensions.cs
@@ -7,6 +7,32 @@ using System.Data;
 
 namespace ReceptRegister.Api;
 
+/// <summary>
+/// Registers and maps diagnostic/health endpoints for the API host.
+/// Endpoints provided:
+///   GET /api/health         - Liveness + (quasi) readiness: status = starting|ok|error. Optional detailed stack trace when explicitly enabled.
+///   GET /api/startup-error  - Plain text output of the startup exception (short or full) under same exposure rules.
+///   GET /api/db-ping        - Lightweight connectivity probe + timing + minimal connection metadata.
+///   GET /api/migrations     - Lists applied and pending schema migrations (best‑effort if history table present).
+///
+/// Security / Exposure:
+///   Full exception detail is ONLY returned when one of these is true:
+///     - ASPNETCORE_ENVIRONMENT == Development (env.IsDevelopment()).
+///     - AppSetting: Diagnostics:ExposeHealthErrors = true.
+///     - Environment variable EXPOSE_HEALTH_ERRORS=true.
+///   Otherwise only a short "Type: Message" is emitted. This avoids leaking stack traces in production by default.
+///
+/// Operational Notes:
+///   - /api/health intentionally avoids heavy dependencies (no DB IO when already failed/starting) to stay fast.
+///   - /api/db-ping performs an actual open + simple SELECT to validate credentials/network.
+///   - /api/migrations performs reflection to enumerate migration classes; if this becomes hot, consider caching.
+///   - If startup initialization fails (schema etc.), the process keeps running so the platform can surface JSON error state instead of generic 503 pages.
+///
+/// Future Enhancements (optional):
+///   - Add a reduced /api/ready endpoint that only returns ok when initialized & not failed.
+///   - Redact sensitive substrings in FullError if certain providers embed secrets.
+///   - Include build/version metadata (commit hash) in /api/health for traceability.
+/// </summary>
 public static class HealthExtensions
 {
 	public static IServiceCollection AddAppHealth(this IServiceCollection services)
@@ -20,12 +46,21 @@ public static class HealthExtensions
 
 	public static IEndpointRouteBuilder MapAppHealth(this IEndpointRouteBuilder endpoints)
 	{
-		// To avoid conflicts with frontend /health when unified, expose JSON health at /api/health.
-		endpoints.MapGet("/api/health", (StartupStatus status) =>
+		// Primary health endpoint (JSON). Chosen path /api/health to avoid collision with frontend root /health.
+		endpoints.MapGet("/api/health", (HttpContext ctx, StartupStatus status, IConfiguration config, IWebHostEnvironment env) =>
 		{
+			bool detailRequested = ctx.Request.Query.ContainsKey("details") || ctx.Request.Query.ContainsKey("detail");
+			bool allowDetails = env.IsDevelopment() || config.GetValue<bool>("Diagnostics:ExposeHealthErrors") || string.Equals(Environment.GetEnvironmentVariable("EXPOSE_HEALTH_ERRORS"), "true", StringComparison.OrdinalIgnoreCase);
 			if (status.Failed)
 			{
-				return Results.Json(new { status = "error", app = "api", initialized = status.IsInitialized, error = status.Error });
+				return Results.Json(new
+				{
+					status = "error",
+					app = "api",
+					initialized = status.IsInitialized,
+					error = status.Error,
+					errorDetail = detailRequested && allowDetails ? status.FullError : null
+				});
 			}
 			if (!status.IsInitialized)
 			{
@@ -34,7 +69,17 @@ public static class HealthExtensions
 			return Results.Json(new { status = "ok", app = "api", initialized = true });
 		});
 
-		// Lightweight DB connectivity probe: attempts open + SELECT 1. Returns basic timing and provider kind.
+<<<<<<< HEAD
+		// Plain text convenience endpoint for quick copy/paste of startup error (respects same exposure gating as /api/health?details).
+		endpoints.MapGet("/api/startup-error", (StartupStatus status, IConfiguration config, IWebHostEnvironment env) =>
+		{
+			if (!status.Failed) return Results.Text("No startup error.");
+			bool allowDetails = env.IsDevelopment() || config.GetValue<bool>("Diagnostics:ExposeHealthErrors") || string.Equals(Environment.GetEnvironmentVariable("EXPOSE_HEALTH_ERRORS"), "true", StringComparison.OrdinalIgnoreCase);
+			if (!allowDetails) return Results.Text(status.Error ?? "Startup failed", "text/plain");
+			return Results.Text(status.FullError ?? status.Error ?? "Startup failed", "text/plain");
+		});
+
+		// Lightweight DB connectivity probe: open + simple SELECT. Avoids schema enumerations; returns timing + provider + parsed server/database.
 		endpoints.MapGet("/api/db-ping", async (IDbConnectionFactory factory, DatabaseOptions opts) =>
 		{
 			var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -42,7 +87,7 @@ public static class HealthExtensions
 			{
 				await using var conn = factory.Create();
 				await conn.OpenAsync();
-				await using (var cmd = conn.CreateCommand()) { cmd.CommandText = opts.Provider == "SqlServer" ? "SELECT 1" : "SELECT 1"; await cmd.ExecuteScalarAsync(); }
+				await using (var cmd = conn.CreateCommand()) { cmd.CommandText = "SELECT 1"; await cmd.ExecuteScalarAsync(); }
 				sw.Stop();
 				string? server = null, database = null;
 				try
@@ -68,7 +113,7 @@ public static class HealthExtensions
 			}
 		});
 
-		// Migrations endpoint: lists applied + pending
+		// Migrations endpoint: best-effort list of applied & pending migrations (reflection each call). Safe if history table missing.
 		endpoints.MapGet("/api/migrations", async (IDbConnectionFactory factory, DatabaseOptions opts) =>
 		{
 			await using var conn = factory.Create();

--- a/ReceptRegister.Api/Program.cs
+++ b/ReceptRegister.Api/Program.cs
@@ -40,7 +40,18 @@ if (migrateArg is not null)
 }
 
 // Ensure database schema exists (tables created) before handling requests (provider-specific)
-await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
+// Capture any initialization failure instead of crashing the process so we can surface details via /api/health.
+var startupStatus = app.Services.GetRequiredService<StartupStatus>();
+try
+{
+	await app.Services.GetRequiredService<ISchemaInitializer>().InitializeAsync();
+	startupStatus.ReportSuccess();
+}
+catch (Exception ex)
+{
+	startupStatus.ReportFailure(ex);
+	// Continue booting: app will report error state via health endpoint.
+}
 
 app.UseAuthSession();
 app.MapApiEndpoints();

--- a/ReceptRegister.Api/StartupStatus.cs
+++ b/ReceptRegister.Api/StartupStatus.cs
@@ -10,7 +10,14 @@ public sealed class StartupStatus
     public bool IsInitialized => InitializedAt is not null;
     public DateTimeOffset? InitializedAt { get; private set; }
     public bool Failed => _initException is not null;
+<<<<<<< HEAD
+    /// <summary>Short error (type + message) safe for basic health display.</summary>
+    public string? Error => _initException is null ? null : _initException.GetType().Name + ": " + _initException.Message;
+    /// <summary>Full exception.ToString() (stack trace etc). Only expose conditionally.</summary>
+    public string? FullError => _initException?.ToString();
+=======
     public string? Error => _initException?.GetType().Name + ": " + _initException?.Message;
+>>>>>>> origin/main
     public void ReportSuccess()
     {
         InitializedAt = DateTimeOffset.UtcNow;

--- a/ReceptRegister.Api/StartupStatus.cs
+++ b/ReceptRegister.Api/StartupStatus.cs
@@ -10,14 +10,10 @@ public sealed class StartupStatus
     public bool IsInitialized => InitializedAt is not null;
     public DateTimeOffset? InitializedAt { get; private set; }
     public bool Failed => _initException is not null;
-<<<<<<< HEAD
     /// <summary>Short error (type + message) safe for basic health display.</summary>
     public string? Error => _initException is null ? null : _initException.GetType().Name + ": " + _initException.Message;
     /// <summary>Full exception.ToString() (stack trace etc). Only expose conditionally.</summary>
     public string? FullError => _initException?.ToString();
-=======
-    public string? Error => _initException?.GetType().Name + ": " + _initException?.Message;
->>>>>>> origin/main
     public void ReportSuccess()
     {
         InitializedAt = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Backport of main commit 8327db52b2a09a91661bf70a66726e84f83e9af9 to release/preview-5.

Includes:
- /api/health with optional ?details gated stack traces
- /api/startup-error plaintext endpoint
- StartupStatus full exception retention
- SQL Server Entra ID token acquisition timeout safeguard
- Simplified db ping (SELECT 1)
- SchemaMigrator readability improvement
- pr-policy regex cleanup (if not already present)

Verification:
- Cherry-pick produced commit afb2168 with no remaining conflicts after manual resolution of HealthExtensions comment section.
- Build expected to remain green; only additive diagnostics.

Risk: Low.

Request: Merge to align release branch diagnostics with main for operational parity.