### PR TITLE
fix(api): resolve leftover merge markers in StartupStatus (preview-6)

### DIFF
--- a/ReceptRegister.Api/StartupStatus.cs
+++ b/ReceptRegister.Api/StartupStatus.cs
@@ -10,14 +10,10 @@ public sealed class StartupStatus
     public bool IsInitialized => InitializedAt is not null;
     public DateTimeOffset? InitializedAt { get; private set; }
     public bool Failed => _initException is not null;
-<<<<<<< HEAD
     /// <summary>Short error (type + message) safe for basic health display.</summary>
     public string? Error => _initException is null ? null : _initException.GetType().Name + ": " + _initException.Message;
     /// <summary>Full exception.ToString() (stack trace etc). Only expose conditionally.</summary>
     public string? FullError => _initException?.ToString();
-=======
-    public string? Error => _initException?.GetType().Name + ": " + _initException?.Message;
->>>>>>> origin/main
     public void ReportSuccess()
     {
         InitializedAt = DateTimeOffset.UtcNow;


### PR DESCRIPTION
### Summary
Removes lingering merge conflict markers in `StartupStatus.cs` that caused CI build failures (CS8300) on the `release/preview-6` branch.

### Problem
Release build failed with:
```
error CS8300: Merge conflict marker encountered StartupStatus.cs
```
The file still contained `<<<<<<< HEAD` / `=======` / `>>>>>>> origin/main` markers from an earlier partial backport / merge.

### Fix
- Cleanly removed conflict markers.
- Kept the enhanced implementation including both `Error` (short form) and `FullError` (full stack) properties used by the health diagnostics endpoints.
- Verified `dotnet build ReceptRegister.Api` succeeds locally after the change.

### Risk
Low. Only removes markers and unifies the intended code path; no behavioral change beyond enabling successful compilation.

### Validation
- Local build (Debug) successful after edit.
- Grep scan for additional conflict markers returned no results.

### Follow-ups (Optional)
- Merge this PR, confirm release workflow re-runs clean on `release/preview-6`.
- Proceed with publishing preview-6 (if workflow is push-triggered it will proceed automatically once branch is green).

---
Checklist:
- [x] Build succeeds locally
- [x] No remaining conflict markers

Please merge when CI passes.
