### PR TITLE
fix(sqlserver): attach transaction to commands in initializer

### DIFF
--- a/ReceptRegister.Api/Data/SqlServerSchemaInitializer.cs
+++ b/ReceptRegister.Api/Data/SqlServerSchemaInitializer.cs
@@ -80,6 +80,8 @@ public sealed class SqlServerSchemaInitializer : ISchemaInitializer
         {
             await using var cmd = conn.CreateCommand();
             cmd.CommandText = sql;
+            // Ensure commands execute within the opened local transaction
+            cmd.Transaction = tx;
             await cmd.ExecuteNonQueryAsync(ct);
         }
         await tx.CommitAsync(ct);


### PR DESCRIPTION
Fixes SQL Server schema initialization failure in Azure by ensuring each command participates in the opened local transaction.

- Change: set `cmd.Transaction = tx;` for each DDL command in `SqlServerSchemaInitializer.InitializeAsync()`
- Why: Without this, SqlClient throws: `BeginExecuteNonQuery requires the command to have a transaction when the connection is in a pending local transaction.`
- Verified: Build + tests pass locally.

After merge, please promote main → release/preview-6 to take this to production. I can open that PR next.